### PR TITLE
Support building on 64-bit MSYS2

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -40,6 +40,9 @@ else ifeq ($(TARGET), x86_64-pc-cygwin)
 else ifeq ($(TARGET), i686-pc-msys)
   platform := msys
   zip_files := ../docs/readme-msys.html
+else ifeq ($(TARGET), x86_64-pc-msys)
+  platform := msys
+  zip_files := ../docs/readme-msys.html
 else
   $(error Target '$(TARGET)' not supported)
 endif


### PR DESCRIPTION
This brings @Alexpux' patch from

https://github.com/Alexpux/MSYS2-packages/blob/master/mintty/02-mintty-add-msys-64bit.patch

upstream, with a minor change that prefixes the zip_files path with "../".