### PR TITLE
Limited Per-monitor DPI support

### DIFF
--- a/src/res.mft
+++ b/src/res.mft
@@ -12,11 +12,6 @@
       />
     </dependentAssembly>
   </dependency>
-  <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
-      <dpiAware>true</dpiAware>
-    </asmv3:windowsSettings>
-  </asmv3:application>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -911,10 +911,6 @@ win_proc(HWND wnd, UINT message, WPARAM wp, LPARAM lp)
           r->left, r->top, r->right - r->left, r->bottom - r->top,
           SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_NOACTIVATE);
         win_adapt_term_size(false, true);
-
-        char buf[256];
-        sprintf(buf, "SM_CXVSCROLL=%d", GetSystemMetrics(SM_CXVSCROLL));
-        SetWindowTextA(wnd, buf);
         return 0;
       }
       break;


### PR DESCRIPTION
On per-monitor DPI environment, the texts on mintty gets very blurry.
This patch make the texts clear although it still could not resize the window caption and scrollbar.
