### PR TITLE
Better support for pinning to the task bar

### DIFF
--- a/docs/mintty.1
+++ b/docs/mintty.1
@@ -990,6 +990,20 @@ be done using the \fBwin7appid\fP utility available from
 \fIhttp://win7appid.googlecode.com\fP.
 
 .TP
+\fBRelaunch Command\fP (RelaunchCommand=)
+Windows 7 and above allow pinning applications to the taskbar. With this
+property, the command line to be called can be customized. Note that the
+Relaunch Display Name and the Application ID property need to be set,
+too, or the setting will be ignored by Windows.
+
+.TP
+\fBRelaunch Display Name\fP (RelaunchDisplayName=)
+Windows 7 and above allow pinning applications to the taskbar. With this
+property, the label of the taskbar menu can be customized. Note that the
+Application ID property needs to be set, too, or the setting will be ignored
+by Windows.
+
+.TP
 \fBWord selection characters\fP (WordChars=)
 By default, this string setting is empty, in which case double-click word
 selection uses the default algorithm that is geared towards picking out

--- a/src/config.c
+++ b/src/config.c
@@ -87,6 +87,8 @@ const config default_cfg = {
   .daemonize = true,
   // "Hidden"
   .app_id = "",
+  .relaunch_command = "",
+  .relaunch_display_name = "",
   .col_spacing = 0,
   .row_spacing = 0,
   .word_chars = "",
@@ -212,6 +214,8 @@ options[] = {
   // "Hidden"
   {"AppID", OPT_STRING, offcfg(app_id)},
   {"ColSpacing", OPT_INT, offcfg(col_spacing)},
+  {"RelaunchCommand", OPT_STRING, offcfg(relaunch_command)},
+  {"RelaunchDisplayName", OPT_STRING, offcfg(relaunch_display_name)},
   {"RowSpacing", OPT_INT, offcfg(row_spacing)},
   {"WordChars", OPT_STRING, offcfg(word_chars)},
   {"WordCharsExcl", OPT_STRING, offcfg(word_chars_excl)},

--- a/src/config.h
+++ b/src/config.h
@@ -107,7 +107,7 @@ typedef struct {
   int x, y;
   bool daemonize;
   // "Hidden"
-  string app_id;
+  string app_id, relaunch_command, relaunch_display_name;
   int col_spacing, row_spacing;
   string word_chars;
   string word_chars_excl;

--- a/src/std.h
+++ b/src/std.h
@@ -41,7 +41,7 @@ int vasprintf(char **, const char *, va_list);
 
 char *asform(const char *fmt, ...);
 
-#define WINVER 0x500  // Windows 2000
+#define WINVER 0x601  // Windows 7
 #define _WIN32_WINNT WINVER
 #define _WIN32_IE WINVER
 

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -47,6 +47,10 @@ typedef struct {
   int cyBottomHeight;
 } MARGINS;
 
+#else
+
+#include <uxtheme.h>
+
 #endif
 
 static HRESULT (WINAPI * pDwmIsCompositionEnabled)(BOOL *) = 0;

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -1268,8 +1268,8 @@ main(int argc, char *argv[])
   }
 
 #if WINVER >= 0x601
-  // Set the app ID explicitly
-  if (*cfg.app_id) {
+  // Set the app ID explicitly, as well as the relaunch command and display name
+  if (*cfg.app_id || *cfg.relaunch_command || *cfg.relaunch_display_name) {
     HMODULE shell = load_sys_library("shell32.dll");
     HRESULT (WINAPI *pGetPropertyStore)(HWND hwnd, REFIID riid, void **ppv) =
       (void *)GetProcAddress(shell, "SHGetPropertyStoreForWindow");
@@ -1290,6 +1290,26 @@ main(int argc, char *argv[])
             var.vt = VT_LPWSTR;
             pps->lpVtbl->SetValue(pps,
                 &PKEY_AppUserModel_ID, &var);
+          }
+        }
+        if (*cfg.relaunch_command &&
+            (size = cs_mbstowcs(0, cfg.relaunch_command, 0) + 1)) {
+          var.pwszVal = malloc(size * sizeof(wchar));
+          if (var.pwszVal) {
+            cs_mbstowcs(var.pwszVal, cfg.relaunch_command, size);
+            var.vt = VT_LPWSTR;
+            pps->lpVtbl->SetValue(pps,
+                &PKEY_AppUserModel_RelaunchCommand, &var);
+          }
+        }
+        if (*cfg.relaunch_display_name &&
+            (size = cs_mbstowcs(0, cfg.relaunch_display_name, 0) + 1)) {
+          var.pwszVal = malloc(size * sizeof(wchar));
+          if (var.pwszVal) {
+            cs_mbstowcs(var.pwszVal, cfg.relaunch_display_name, size);
+            var.vt = VT_LPWSTR;
+            pps->lpVtbl->SetValue(pps,
+                &PKEY_AppUserModel_RelaunchDisplayNameResource, &var);
           }
         }
         pps->lpVtbl->Commit(pps);


### PR DESCRIPTION
Windows 7 allows users to pin running applications to the task bar. However, when launching `mintty` from another process, clicking the pinned icon will call `mintty` instead of the executable of the calling process.

To help with this issue, this Pull Request adds support for two new options:

- `RelaunchDisplayName`: override the name shown in the task bar
- `RelaunchCommand` override the command-line to call from the icon pinned to the task bar

Note that Windows will simply ignore the relaunch command setting unless both the display name and the application ID are configured, too.

Please note also that the way `mintty` configures the application ID currently (`SetCurrentProcessExplicitAppUserModelID`) did not work correctly in this developer's setup (Windows Server 2012 R2): when configuring the application ID of the calling process and of `mintty` so they would match, the pinned icon would *still* launch `mintty` directly. This was only fixed by setting the application ID *explicitly* for the `mintty` terminal window (this is what the first commit is all about).

Background: [Git for Windows 2.x](https://git-for-windows.github.io/) is slated to ship with `mintty` as its default terminal emulator for "Git Bash", launched as `git-bash.exe`, and we want `git-bash.exe` to be called when a pinned *Git Bash* icon is clicked by the user.