### PR TITLE
rupor-github

### DIFF
--- a/src/winmain.c
+++ b/src/winmain.c
@@ -690,7 +690,7 @@ win_adapt_term_size(bool sync_size_with_font, bool scale_font_with_size)
   int term_width = client_width - 2 * PADDING;
   int term_height = client_height - 2 * PADDING;
 
-  if (scale_font_with_size) {
+  if (scale_font_with_size && term.cols != 0 && term.rows != 0) {
     // calc preliminary size (without font scaling), as below
     // should use term_height rather than rows; calc and store in term_resize
     int cols0 = max(1, term_width / font_width);


### PR DESCRIPTION
When running "mintty -p@2" on msys2 under Windows 10 WM_DPICHANGED (and win_adapt_term_size(false,*true*)) happens before term structure was initialized with proper sizes.