### PR TITLE
Font re-sizing on WM_DPICHANGED

### DIFF
--- a/src/winmain.c
+++ b/src/winmain.c
@@ -728,9 +728,9 @@ win_adapt_term_size(bool sync_size_with_font, bool scale_font_with_size)
       // bigger
       //   ? font_size * rows0 * cols0 / (term.rows * term.cols)
       //   : font_size * rows0 * cols0 / (term.rows * term.cols);
-	
-	trace_resize(("term size %d %d -> %d %d\n", term.rows, term.cols, rows0, cols0));
-	trace_resize(("font size %d -> %d\n", font_size, font_size1));
+
+    trace_resize(("term size %d %d -> %d %d\n", term.rows, term.cols, rows0, cols0));
+    trace_resize(("font size %d -> %d\n", font_size, font_size1));
 
     if (font_size1 != font_size)
       win_set_font_size(font_size1, false);
@@ -1163,7 +1163,7 @@ static struct {
 #endif
         bool scale_font = (cfg.zoom_font_with_window || zoom_token > 2)
                           && (zoom_token > 0) && (GetKeyState(VK_SHIFT) & 0x80);
-		
+
         win_adapt_term_size(false, scale_font);
         if (zoom_token > 0)
           zoom_token = zoom_token >> 1;
@@ -1180,16 +1180,17 @@ static struct {
         WORD x_dpi = LOWORD(wp);
 
 #ifdef debug_dpi
-	    printf("WM_DPICHANGED %d L,T,R,B=%d,%d,%d,%d WxH=%dx%d, %d -> %d\n", per_monitor_dpi_aware, r->left, r->top, r->right, r->bottom, r->right - r->left, r->bottom - r->top, last_dpi, x_dpi);
+        printf("WM_DPICHANGED %d L,T,R,B=%d,%d,%d,%d WxH=%dx%d, %d -> %d\n", per_monitor_dpi_aware, r->left, r->top, r->right, r->bottom, r->right - r->left, r->bottom - r->top, last_dpi, x_dpi);
 #endif
-		if (last_dpi < 0) {
-        	int font_size1 = round((double)font_size * x_dpi / last_dpi);
-        	win_set_font_size(font_size1, false);
+        if (last_dpi < 0) {
+          int font_size1 = round((double)font_size * x_dpi / last_dpi);
+          win_set_font_size(font_size1, false);
+
 #ifdef debug_dpi
-        	printf("font_size: %d -> %d\n", font_size, font_size1);
+          printf("font_size: %d -> %d\n", font_size, font_size1);
 #endif
-		}
-		last_dpi = x_dpi;
+        }
+        last_dpi = x_dpi;
 
 #ifdef debug_dpi
         printf("SM_CXVSCROLL %d\n", GetSystemMetrics(SM_CXVSCROLL));
@@ -1199,7 +1200,7 @@ static struct {
           r->left, r->top, r->right - r->left, r->bottom - r->top,
           SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_NOACTIVATE);
 
-		win_adapt_term_size(false, true);
+        win_adapt_term_size(false, true);
         return 0;
       }
       break;
@@ -1932,7 +1933,7 @@ main(int argc, char *argv[])
 
 #define dont_debug_position
 #ifdef debug_position
-#define printpos(tag, x, y, mon)	printf("%s %d %d (%ld %ld %ld %ld)\n", tag, x, y, mon.left, mon.top, mon.right, mon.bottom);
+#define printpos(tag, x, y, mon)  printf("%s %d %d (%ld %ld %ld %ld)\n", tag, x, y, mon.left, mon.top, mon.right, mon.bottom);
 #else
 #define printpos(tag, x, y, mon)
 #endif

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -17,6 +17,7 @@
 #include <getopt.h>
 #include <pwd.h>
 #include <shellapi.h>
+#include <math.h>
 
 #include <sys/cygwin.h>
 
@@ -64,6 +65,7 @@ static bool maxwidth = false;
 static bool maxheight = false;
 static bool store_taskbar_properties = false;
 static bool prevent_pinning = false;
+static int last_dpi = 0;
 
 static HBITMAP caretbm;
 
@@ -123,6 +125,7 @@ const int Process_Per_Monitor_DPI_Aware  = 2;
 const int MDT_Effective_DPI = 0;
 static HRESULT (WINAPI * pGetProcessDpiAwareness)(HANDLE hprocess, int * value) = 0;
 static HRESULT (WINAPI * pSetProcessDpiAwareness)(int value) = 0;
+static HRESULT (WINAPI * pGetDpiForMonitor)(HMONITOR hmonitor, int dpiType, UINT * dpiX, UINT * dpiY);
 
 static void
 load_shcore_funcs(void)
@@ -136,6 +139,8 @@ load_shcore_funcs(void)
       (void *)GetProcAddress(shc, "GetProcessDpiAwareness");
     pSetProcessDpiAwareness =
       (void *)GetProcAddress(shc, "SetProcessDpiAwareness");
+    pGetDpiForMonitor =
+      (void *)GetProcAddress(shc, "GetDpiForMonitor");
 #ifdef debug_dpi
       printf("SetProcessDpiAwareness %d GetProcessDpiAwareness %d\n", !!pSetProcessDpiAwareness, !!pGetProcessDpiAwareness);
 #endif
@@ -723,8 +728,9 @@ win_adapt_term_size(bool sync_size_with_font, bool scale_font_with_size)
       // bigger
       //   ? font_size * rows0 * cols0 / (term.rows * term.cols)
       //   : font_size * rows0 * cols0 / (term.rows * term.cols);
-      trace_resize(("term size %d %d -> %d %d\n", term.rows, term.cols, rows0, cols0));
-      trace_resize(("font size %d -> %d\n", font_size, font_size1));
+	
+	trace_resize(("term size %d %d -> %d %d\n", term.rows, term.cols, rows0, cols0));
+	trace_resize(("font size %d -> %d\n", font_size, font_size1));
 
     if (font_size1 != font_size)
       win_set_font_size(font_size1, false);
@@ -1132,7 +1138,7 @@ static struct {
       return ew || eh;
     }
     when WM_SIZE: {
-      trace_resize(("# WM_SIZE (resizing %d) VK_SHIFT %02X\n", resizing, GetKeyState(VK_SHIFT)));
+      trace_resize(("# WM_SIZE (resizing %d) VK_SHIFT %02X %d\n", resizing, GetKeyState(VK_SHIFT), zoom_token));
       if (wp == SIZE_RESTORED && win_is_fullscreen)
         clear_fullscreen();
       else if (wp == SIZE_MAXIMIZED && go_fullscr_on_max) {
@@ -1157,6 +1163,7 @@ static struct {
 #endif
         bool scale_font = (cfg.zoom_font_with_window || zoom_token > 2)
                           && (zoom_token > 0) && (GetKeyState(VK_SHIFT) & 0x80);
+		
         win_adapt_term_size(false, scale_font);
         if (zoom_token > 0)
           zoom_token = zoom_token >> 1;
@@ -1168,18 +1175,31 @@ static struct {
       win_update_menus();
       return 0;
     when WM_DPICHANGED:
-#ifdef debug_dpi
-      printf("WM_DPICHANGED %d\n", per_monitor_dpi_aware);
-#endif
       if (per_monitor_dpi_aware) {
         LPRECT r = (LPRECT) lp;
-        SetWindowPos(wnd, 0,
-          r->left, r->top, r->right - r->left, r->bottom - r->top,
-          SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_NOACTIVATE);
-        win_adapt_term_size(false, true);
+        WORD x_dpi = LOWORD(wp);
+
+#ifdef debug_dpi
+	    printf("WM_DPICHANGED %d L,T,R,B=%d,%d,%d,%d WxH=%dx%d, %d -> %d\n", per_monitor_dpi_aware, r->left, r->top, r->right, r->bottom, r->right - r->left, r->bottom - r->top, last_dpi, x_dpi);
+#endif
+		if (last_dpi < 0) {
+        	int font_size1 = round((double)font_size * x_dpi / last_dpi);
+        	win_set_font_size(font_size1, false);
+#ifdef debug_dpi
+        	printf("font_size: %d -> %d\n", font_size, font_size1);
+#endif
+		}
+		last_dpi = x_dpi;
+
 #ifdef debug_dpi
         printf("SM_CXVSCROLL %d\n", GetSystemMetrics(SM_CXVSCROLL));
 #endif
+
+        SetWindowPos(wnd, 0,
+          r->left, r->top, r->right - r->left, r->bottom - r->top,
+          SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_NOACTIVATE);
+
+		win_adapt_term_size(false, true);
         return 0;
       }
       break;


### PR DESCRIPTION
To correct #487 and #492. This does not change windows sizing behavior mentioned in #492 when mintty window moved between screens with Win shortcuts - this is Windows, program works as designed.