### PR TITLE
Update to build correctly on Cygwin 2.5

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -80,7 +80,7 @@ rc_srcs := $(wildcard *.rc)
 objs := $(c_srcs:.c=.o) $(rc_srcs:.rc=.o)
 bins := $(patsubst %.o,$(BINDIR)/%.o,$(objs))
 
-CFLAGS := -std=gnu99 -include std.h -Wall -Wextra -Wundef -Werror
+CFLAGS := -D_XOPEN_SOURCE -D_GNU_SOURCE -std=gnu99 -include std.h -Wall -Wextra -Wundef -Werror
 
 ifeq ($(shell VER=`$(CC) -dumpversion`; expr $${VER%.*} '>=' 4.5), 1)
   CFLAGS += -mtune=atom

--- a/src/ctrls.c
+++ b/src/ctrls.c
@@ -6,6 +6,8 @@
 
 #include "ctrls.h"
 
+#include <string.h>
+
 /*
  * ctrls.c - a reasonably platform-independent mechanism for
  * describing window controls.


### PR DESCRIPTION
Some functions, like `asprintf` and `ptsname`, are now available only after
requesting non-POSIX behavior, using `_GNU_SOURCE` and `_XOPEN_SOURCE`.

Include `<string.h>` in `ctrls.c` for `strdup`.

Cygwin 2.5.0 is currently in testing (unreleased). MSYS2 has already integrated these changes with the  2.5.0.17040.9d5d874-1 release.