### PR TITLE
term: Add osc52 clipboard support.

### DIFF
--- a/src/base64.c
+++ b/src/base64.c
@@ -1,3 +1,7 @@
+// base64.c (part of mintty)
+// Copyright 2016 Jianbin Kang
+// Licensed under the terms of the GNU General Public License v3 or later.
+
 #include <errno.h>
 #include <stdint.h>
 #include "base64.h"

--- a/src/base64.c
+++ b/src/base64.c
@@ -1,0 +1,272 @@
+#include <errno.h>
+#include <stdint.h>
+#include "base64.h"
+
+static const char base64_table[] = {
+  'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
+  'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
+  'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
+  'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
+  'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
+  'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
+  'w', 'x', 'y', 'z', '0', '1', '2', '3',
+  '4', '5', '6', '7', '8', '9', '+', '/',
+};
+
+#define INVALID_CHAR	(-1)
+
+static inline char encode(uint32_t v)
+{
+  return base64_table[v];
+}
+
+static inline int decode(char v)
+{
+  if (v >= 'A' && v <= 'Z') {
+    return v - 'A';
+  }
+  if (v >= 'a' && v <= 'z') {
+    return v - 'a' + 26;
+  }
+  if (v >= '0' && v <= '9') {
+    return v - '0' + 52;
+  }
+  if (v == '+') {
+    return 62;
+  }
+  if (v == '/') {
+    return 63;
+  }
+  return INVALID_CHAR;
+
+}
+
+int base64_encode(const char *input, int ilen, char *output, int olen)
+{
+  int calc_len = (ilen + 2) / 3 * 4;
+  int i = 0;
+
+  if (olen < calc_len) {
+    return B64_OVERFLOW;
+  }
+  while (ilen >= 3) {
+    uint32_t v = (((uint32_t)input[0]) << 16) +
+      (((uint32_t)input[1]) << 8) + input[2];
+    output[i] = encode(v >> 18);
+    output[i + 1] = encode((v >> 12) & 0x3f);
+    output[i + 2] = encode((v >> 6) & 0x3f);
+    output[i + 3] = encode(v & 0x3f);
+    i += 4;
+    input += 3;
+    ilen -= 3;
+  }
+  if (ilen > 0) {
+    uint32_t v = ((uint32_t)input[0]) << 16;
+    if (ilen == 2) {
+      v += ((uint32_t)input[1]) << 8;
+    }
+    output[i] = encode(v >> 18);
+    output[i + 1] = encode((v >> 12) & 0x3f);
+    if (ilen == 1) {
+      output[i + 2] = '=';
+    } else {
+      output[i + 2] = encode((v >> 6) & 0x3f);
+    }
+    output[i+3] = '=';
+    i += 4;
+  }
+  return i;
+}
+
+static int decode_chars(const char *input, int num)
+{
+  int i;
+  int dec_v = 0;
+  int step = 18;
+
+  for (i = 0; i < num; i += 1, step -= 6) {
+    int v = decode(input[i]);
+    if (v == INVALID_CHAR) {
+      return B64_INVALID_CHAR;
+    }
+    dec_v += v << step;
+  }
+  return dec_v;
+}
+
+static int do_decode(const char *input, int ilen, char *out)
+{
+  int i = 0;
+  int dec_v;
+
+  while (ilen >= 4) {
+    dec_v = decode_chars(input, 4);
+    if (dec_v < 0) {
+      return dec_v;
+    }
+    out[i] = dec_v >> 16;
+    out[i + 1] = (dec_v >> 8) & 0xff;
+    out[i + 2] = dec_v & 0xff;
+    i += 3;
+    ilen -= 4;
+    input += 4;
+  }
+  if (ilen >= 2) {
+    dec_v = decode_chars(input, ilen);
+    out[i] = dec_v >> 16;
+    i += 1;
+    if (ilen == 3) {
+      out[i] = dec_v >> 8;
+      i += 1;
+    }
+  } else if (ilen == 1) {
+    /* It is a bug */
+    return B64_INTERNAL_ERROR;
+  }
+  return i;
+}
+
+int base64_decode_clip(const char *input, int ilen, char *out, int olen)
+{
+  if ((ilen % 4) != 0) {
+    ilen = ilen / 4 * 4;
+  }
+  return base64_decode(input, ilen, out, olen);
+}
+
+int base64_decode(const char *input, int ilen, char *out, int olen)
+{
+  int dec_len;
+  int encode_len;
+  int out_len;
+
+  if (ilen == 0) {
+    return 0;
+  }
+  if ((ilen % 4) != 0) {
+    return B64_INVALID_LEN;
+  }
+  dec_len = ilen / 4 * 3;
+  encode_len = ilen;
+  if (input[ilen - 1] == '=') {
+    dec_len -= 1;
+    encode_len -= 1;
+  }
+  if (input[ilen - 2] == '=') {
+    dec_len -= 1;
+    encode_len -= 1;
+  }
+  if (olen < dec_len) {
+    return B64_INVALID_LEN;
+  }
+  out_len = do_decode(input, encode_len, out);
+  if (out_len != dec_len) {
+    return B64_INTERNAL_INVALID_LEN;
+  }
+  return out_len;
+}
+
+
+#ifdef BASE64_TEST
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "base64.h"
+
+struct base64_test {
+  const char *orig;
+  const char *encode;
+};
+
+static struct base64_test test_sets[] = {
+  { "A", "QQ==", },
+  { "AA", "QUE=", },
+  { "AAA", "QUFB", },
+  { "AB", "QUI=", },
+  { "ABC", "QUJD", },
+  { "ABCD", "QUJDRA==" },
+  { "ABCDE", "QUJDREU=" },
+  { "ABCDEF", "QUJDREVG" },
+  { "ABCDEFG", "QUJDREVGRw==" },
+  { "ABCDEFGH", "QUJDREVGR0g=" },
+  { "ABCDEFGHI", "QUJDREVGR0hJ" },
+};
+
+#define ARRAY_SIZE(a)		(sizeof(a) / sizeof(a[0]))
+
+#define error(fmt, ...)	do {                    \
+    fprintf(stderr, fmt, ##__VA_ARGS__);	\
+    exit(1);                                    \
+  } while (0)
+
+static void encode_string(const char *s, char *out, int len)
+{
+  int out_len;
+
+  out_len = base64_encode(s, strlen(s), out, len - 1);
+  if (out_len < 0) {
+    error("Encode %s with len %d return %d\n", s, len, out_len);
+  }
+  if (out_len > len - 1) {
+    error("Encode %s with len %d return invalid len %d\n",
+          s, len, out_len);
+  }
+  out[out_len] = '\0';
+}
+
+static void decode_string(const char *s, char *out, int len)
+{
+  int out_len;
+
+  out_len = base64_decode(s, strlen(s), out, len - 1);
+  if (out_len < 0) {
+    error("Encode %s with len %d return %d\n", s, len, out_len);
+  }
+  if (out_len > len - 1) {
+    error("Encode %s with len %d return invalid len %d\n",
+          s, len, out_len);
+  }
+  out[out_len] = '\0';
+}
+
+static void test_encode(void)
+{
+  char buf[1024];
+  unsigned int i;
+
+  for (i = 0; i < ARRAY_SIZE(test_sets); i += 1) {
+    encode_string(test_sets[i].orig, &buf[0], sizeof(buf));
+    if (strcmp(buf, test_sets[i].encode) != 0) {
+      error("Encode %s return %s, expect %s\n",
+            test_sets[i].orig, buf, test_sets[i].encode);
+    }
+  }
+  printf("Encode PASSED\n");
+}
+
+static void test_decode(void)
+{
+  char buf[1024];
+  unsigned int i;
+
+  for (i = 0; i < ARRAY_SIZE(test_sets); i += 1) {
+    decode_string(test_sets[i].encode, &buf[0], sizeof(buf));
+    if (strcmp(buf, test_sets[i].orig) != 0) {
+      error("Decode %s return %s, expect %s\n",
+            test_sets[i].encode, buf, test_sets[i].orig);
+    }
+  }
+  printf("Decode PASSED\n");
+}
+
+int main(int argc, char *argv[])
+{
+  (void)argc;
+  (void)argv;
+
+  test_encode();
+  test_decode();
+
+  return 0;
+}
+#endif

--- a/src/base64.h
+++ b/src/base64.h
@@ -1,0 +1,18 @@
+#ifndef BASE64_H
+#define BASE64_H
+
+enum {
+  B64_OK,
+  B64_OVERFLOW	= -10000,
+  B64_INVALID_LEN,
+  B64_INVALID_CHAR,
+  B64_INTERNAL_ERROR,
+  B64_INTERNAL_INVALID_LEN,
+};
+
+
+int base64_encode(const char *input, int ilen, char *output, int olen);
+int base64_decode(const char *input, int ilen, char *out, int olen);
+int base64_decode_clip(const char *input, int ilen, char *out, int olen);
+
+#endif

--- a/src/config.c
+++ b/src/config.c
@@ -95,6 +95,7 @@ const config default_cfg = {
   .bell_taskbar = true,
   .printer = W(""),
   .confirm_exit = true,
+  .allow_set_selection = false,
   // Command line
   .class = W(""),
   .hold = HOLD_START,
@@ -247,6 +248,7 @@ options[] = {
   {"BellTaskbar", OPT_BOOL, offcfg(bell_taskbar)},
   {"Printer", OPT_WSTRING, offcfg(printer)},
   {"ConfirmExit", OPT_BOOL, offcfg(confirm_exit)},
+  {"AllowSetSelection", OPT_BOOL, offcfg(allow_set_selection)},
 
   // Command line
   {"Class", OPT_WSTRING, offcfg(class)},

--- a/src/config.h
+++ b/src/config.h
@@ -109,6 +109,7 @@ typedef struct {
   bool bell_taskbar;
   wstring printer;
   bool confirm_exit;
+  bool allow_set_selection;
   // Command line
   wstring class;
   char hold;

--- a/src/term.c
+++ b/src/term.c
@@ -115,6 +115,17 @@ term_cursor_reset(term_cursor *curs)
   curs->autowrap = true;
 }
 
+
+void term_init(void)
+{
+  term_cmd_buf_init();
+}
+
+void term_release(void)
+{
+  term_cmd_buf_release();
+}
+
 void
 term_reset(void)
 {

--- a/src/term.c
+++ b/src/term.c
@@ -115,20 +115,14 @@ term_cursor_reset(term_cursor *curs)
   curs->autowrap = true;
 }
 
-
-void term_init(void)
-{
-  term_cmd_buf_init();
-}
-
-void term_release(void)
-{
-  term_cmd_buf_release();
-}
-
 void
 term_reset(void)
 {
+  if (term.cmd_buf == NULL) {
+    term.cmd_buf = newn(char, 128);
+    term.cmd_buf_cap = 128;
+  }
+
   term.state = NORMAL;
 
   term_cursor_reset(&term.curs);

--- a/src/term.h
+++ b/src/term.h
@@ -389,7 +389,8 @@ struct term {
   uint csi_argv_defined[32];
 
   int  cmd_num;        // OSC command number, or -1 for DCS
-  char cmd_buf[2048];  // OSC or DCS string buffer and length
+  char *cmd_buf;       // OSC or DCS string buffer and length
+  uint cmd_buf_cap;
   uint cmd_len;
   int dcs_cmd;
 
@@ -498,5 +499,10 @@ void term_schedule_search_update(void);
 void term_update_search(void);
 void term_clear_results(void);
 void term_clear_search(void);
+
+void term_init(void);
+void term_release(void);
+void term_cmd_buf_init(void);
+void term_cmd_buf_release(void);
 
 #endif

--- a/src/term.h
+++ b/src/term.h
@@ -500,9 +500,4 @@ void term_update_search(void);
 void term_clear_results(void);
 void term_clear_search(void);
 
-void term_init(void);
-void term_release(void);
-void term_cmd_buf_init(void);
-void term_cmd_buf_release(void);
-
 #endif

--- a/src/win.h
+++ b/src/win.h
@@ -33,6 +33,7 @@ void win_restore_title(void);
 void win_prefix_title(const wstring);
 void win_unprefix_title(const wstring);
 void win_copy_title(void);
+void win_copy_text(const char *s);
 
 colour win_get_colour(colour_i);
 void win_set_colour(colour_i, colour);

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -2489,6 +2489,7 @@ main(int argc, char *argv[])
   }
 
   // Initialise the terminal.
+  term_init();
   term_reset();
   term_resize(term_rows, term_cols);
 
@@ -2542,8 +2543,10 @@ main(int argc, char *argv[])
   for (;;) {
     MSG msg;
     while (PeekMessage(&msg, null, 0, 0, PM_REMOVE)) {
-      if (msg.message == WM_QUIT)
+      if (msg.message == WM_QUIT) {
+        term_release();
         return msg.wParam;
+      }
       if (!IsDialogMessage(config_wnd, &msg))
         DispatchMessage(&msg);
     }

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -234,6 +234,21 @@ win_copy_title(void)
   win_copy(title, 0, len + 1);
 }
 
+void win_copy_text(const char *s)
+{
+  unsigned int size;
+  wchar *text = cs__mbstowcs(s);
+
+  if (text == NULL) {
+    return;
+  }
+  size = wcslen(text);
+  if (size > 0) {
+    win_copy(text, 0, size + 1);
+  }
+  free(text);
+}
+
 void
 win_prefix_title(const wstring prefix)
 {

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -2489,7 +2489,6 @@ main(int argc, char *argv[])
   }
 
   // Initialise the terminal.
-  term_init();
   term_reset();
   term_resize(term_rows, term_cols);
 
@@ -2543,10 +2542,8 @@ main(int argc, char *argv[])
   for (;;) {
     MSG msg;
     while (PeekMessage(&msg, null, 0, 0, PM_REMOVE)) {
-      if (msg.message == WM_QUIT) {
-        term_release();
+      if (msg.message == WM_QUIT)
         return msg.wParam;
-      }
       if (!IsDialogMessage(config_wnd, &msg))
         DispatchMessage(&msg);
     }


### PR DESCRIPTION
Hi mintty experts,
See discussion in #258.
The feature is disabled by default. Nedd set 'AllowSetSelection' to true in .minttyrc to enable it.
Works with UTF-8 and non UTF-8 terminal.
Some limitation:
1. Read from clipborad is not supported.
2. No more than 1536 can be copy into clipboard. (Limits by length of cmd_buf)
3. Always use system clipboard.