### PR TITLE
Fix per-monitor scaling of titlebars

### DIFF
--- a/src/winmain.c
+++ b/src/winmain.c
@@ -1177,8 +1177,9 @@ static struct {
   switch (message) {
     when WM_NCCREATE:
       if (pEnableNonClientDpiScaling) {
-        CREATESTRUCT * csp = (CREATESTRUCT *)lp;
-        BOOL res = pEnableNonClientDpiScaling(csp->hwndParent);
+        resizing = true;
+        BOOL res = pEnableNonClientDpiScaling(wnd);
+        resizing = false;
         (void)res;
 #ifdef debug_dpi
         uint err = GetLastError();


### PR DESCRIPTION
This fixes, at least for me, the scaling of titlebars when using multiple monitors with different DPI.

Everything works as expected, except for context menus which are still too big on the lower-DPI monitor.

One strange issue is that Windows sends a `WM_SIZE` message *during* the call to `EnableNonClientDpiScaling`. At this time, the window is not fully constructed (`WM_CREATE` has not been sent yet), but `win_adapt_term_size` tries to call `GetClientRect`, gets invalid data, and the program crashes. The `resizing = true;`, `resizing = false` code makes mintty ignore `WM_SIZE` during this phase.

Screenshot showing mintty before and after, on my regular-DPI external monitor (the laptop's screen is high-DPI):

![titlebar_scaling](https://cloud.githubusercontent.com/assets/110078/18439027/fcb2a4ce-7903-11e6-87b2-bbae613bf162.png)
