### PR TITLE
Visual bell: support alternative rendering of window-edges only

### DIFF
--- a/docs/mintty.1
+++ b/docs/mintty.1
@@ -1306,6 +1306,10 @@ The sound is also played when it is changed.
 \(en \fBFlash\fP (BellFlash=no): Briefly invert the foreground and background
 colours. (Corresponds to the xterm resource \fBvisualBell\fP.)
 .br
+\(en (BellFlashIsEdge=no): Alternative rendering of \fBFlash\fP
+- only flash the edges of the window, which may be less jarring than the whole
+window.
+.br
 \(en \fBHighlight in taskbar\fP (BellTaskbar=yes): Change the colour of mintty's
 taskbar entry if the mintty window is not active.
 (Corresponds to the xterm resource \fBbellIsUrgent\fP, 

--- a/docs/mintty.1
+++ b/docs/mintty.1
@@ -1306,9 +1306,8 @@ The sound is also played when it is changed.
 \(en \fBFlash\fP (BellFlash=no): Briefly invert the foreground and background
 colours. (Corresponds to the xterm resource \fBvisualBell\fP.)
 .br
-\(en (BellFlashIsEdge=no): Alternative rendering of \fBFlash\fP
-- only flash the edges of the window, which may be less jarring than the whole
-window.
+\(en (BellFlashStyle=0): Alternative rendering of \fBFlash\fP. 1 - only flash
+the edges of the window, which may be less jarring than the whole window.
 .br
 \(en \fBHighlight in taskbar\fP (BellTaskbar=yes): Change the colour of mintty's
 taskbar entry if the mintty window is not active.

--- a/docs/mintty.1.html
+++ b/docs/mintty.1.html
@@ -1,5 +1,5 @@
 <!-- Creator     : groff version 1.22.3 -->
-<!-- CreationDate: Fri Jul 28 16:07:34 2017 -->
+<!-- CreationDate: Fri Aug 11 17:21:53 2017 -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
 "http://www.w3.org/TR/html4/loose.dtd">
 <html>
@@ -1596,6 +1596,9 @@ testing. The sound is also played when it is changed. <br>
 &ndash; <b>Flash</b> (BellFlash=no): Briefly invert the
 foreground and background colours. (Corresponds to the xterm
 resource <b>visualBell</b>.) <br>
+&ndash; (BellFlashIsEdge=no): Alternative rendering of
+<b>Flash</b> - only flash the edges of the window, which may
+be less jarring than the whole window. <br>
 &ndash; <b>Highlight in taskbar</b> (BellTaskbar=yes):
 Change the colour of mintty&rsquo;s taskbar entry if the
 mintty window is not active. (Corresponds to the xterm

--- a/docs/mintty.1.html
+++ b/docs/mintty.1.html
@@ -1,5 +1,5 @@
 <!-- Creator     : groff version 1.22.3 -->
-<!-- CreationDate: Fri Aug 11 17:21:53 2017 -->
+<!-- CreationDate: Fri Aug 25 16:36:09 2017 -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
 "http://www.w3.org/TR/html4/loose.dtd">
 <html>
@@ -1596,9 +1596,9 @@ testing. The sound is also played when it is changed. <br>
 &ndash; <b>Flash</b> (BellFlash=no): Briefly invert the
 foreground and background colours. (Corresponds to the xterm
 resource <b>visualBell</b>.) <br>
-&ndash; (BellFlashIsEdge=no): Alternative rendering of
-<b>Flash</b> - only flash the edges of the window, which may
-be less jarring than the whole window. <br>
+&ndash; (BellFlashStyle=0): Alternative rendering of
+<b>Flash</b>. 1 - only flash the edges of the window, which
+may be less jarring than the whole window. <br>
 &ndash; <b>Highlight in taskbar</b> (BellTaskbar=yes):
 Change the colour of mintty&rsquo;s taskbar entry if the
 mintty window is not active. (Corresponds to the xterm

--- a/src/config.c
+++ b/src/config.c
@@ -118,6 +118,7 @@ const config default_cfg = {
   .bell_freq = 0,
   .bell_len = 400,
   .bell_flash = false,  // xterm: visualBell
+  .bell_flash_is_edge = false, // how .bell_flash is rendered when enabled
   .bell_taskbar = true, // xterm: bellIsUrgent
   .bell_popup = false,  // xterm: popOnBell
   .printer = W(""),
@@ -308,6 +309,7 @@ options[] = {
   {"BellFreq", OPT_INT, offcfg(bell_freq)},
   {"BellLen", OPT_INT, offcfg(bell_len)},
   {"BellFlash", OPT_BOOL, offcfg(bell_flash)},
+  {"BellFlashIsEdge", OPT_BOOL, offcfg(bell_flash_is_edge)},
   {"BellTaskbar", OPT_BOOL, offcfg(bell_taskbar)},
   {"BellPopup", OPT_BOOL, offcfg(bell_popup)},
   {"Printer", OPT_WSTRING, offcfg(printer)},

--- a/src/config.c
+++ b/src/config.c
@@ -118,7 +118,7 @@ const config default_cfg = {
   .bell_freq = 0,
   .bell_len = 400,
   .bell_flash = false,  // xterm: visualBell
-  .bell_flash_is_edge = false, // how .bell_flash is rendered when enabled
+  .bell_flash_style = 0, // bitwise style for rendering bell_flash
   .bell_taskbar = true, // xterm: bellIsUrgent
   .bell_popup = false,  // xterm: popOnBell
   .printer = W(""),
@@ -309,7 +309,7 @@ options[] = {
   {"BellFreq", OPT_INT, offcfg(bell_freq)},
   {"BellLen", OPT_INT, offcfg(bell_len)},
   {"BellFlash", OPT_BOOL, offcfg(bell_flash)},
-  {"BellFlashIsEdge", OPT_BOOL, offcfg(bell_flash_is_edge)},
+  {"BellFlashStyle", OPT_INT, offcfg(bell_flash_style)},
   {"BellTaskbar", OPT_BOOL, offcfg(bell_taskbar)},
   {"BellPopup", OPT_BOOL, offcfg(bell_popup)},
   {"Printer", OPT_WSTRING, offcfg(printer)},

--- a/src/config.h
+++ b/src/config.h
@@ -115,7 +115,7 @@ typedef struct {
   int bell_freq;
   int bell_len;
   bool bell_flash;   // xterm: visualBell
-  bool bell_flash_is_edge;  // how bell_flash is rendered when enabled
+  int bell_flash_style;  // bitwise style for rendering bell_flash
   bool bell_taskbar; // xterm: bellIsUrgent
   bool bell_popup;   // xterm: popOnBell
   wstring printer;

--- a/src/config.h
+++ b/src/config.h
@@ -115,6 +115,7 @@ typedef struct {
   int bell_freq;
   int bell_len;
   bool bell_flash;   // xterm: visualBell
+  bool bell_flash_is_edge;  // how bell_flash is rendered when enabled
   bool bell_taskbar; // xterm: bellIsUrgent
   bool bell_popup;   // xterm: popOnBell
   wstring printer;

--- a/src/term.c
+++ b/src/term.c
@@ -1125,7 +1125,7 @@ term_paint(void)
         );
 
       bool flashchar = term.in_vbell && (
-                         !cfg.bell_flash_is_edge ||
+                         !(cfg.bell_flash_style & 1) ||
                          !i || !j || (i == term.rows - 1) || (j == term.cols - 1)
                        );
 

--- a/src/term.c
+++ b/src/term.c
@@ -1124,12 +1124,15 @@ term_paint(void)
           : posle(term.sel_start, scrpos) && poslt(scrpos, term.sel_end)
         );
 
+      if (selected)
+        tattr.attr ^= ATTR_REVERSE;
+
       bool flashchar = term.in_vbell && (
                          !(cfg.bell_flash_style & 1) ||
                          !i || !j || (i == term.rows - 1) || (j == term.cols - 1)
                        );
 
-      if (selected || flashchar)
+      if (flashchar)
         tattr.attr ^= ATTR_REVERSE;
 
       int match = in_results(scrpos);

--- a/src/term.c
+++ b/src/term.c
@@ -1123,7 +1123,13 @@ term_paint(void)
           ? posPle(term.sel_start, scrpos) && posPlt(scrpos, term.sel_end)
           : posle(term.sel_start, scrpos) && poslt(scrpos, term.sel_end)
         );
-      if (term.in_vbell || selected)
+
+      bool flashchar = term.in_vbell && (
+                         !cfg.bell_flash_is_edge ||
+                         !i || !j || (i == term.rows - 1) || (j == term.cols - 1)
+                       );
+
+      if (selected || flashchar)
         tattr.attr ^= ATTR_REVERSE;
 
       int match = in_results(scrpos);

--- a/src/term.c
+++ b/src/term.c
@@ -1128,12 +1128,83 @@ term_paint(void)
         tattr.attr ^= ATTR_REVERSE;
 
       bool flashchar = term.in_vbell && (
-                         !(cfg.bell_flash_style & 1) ||
+                         !(cfg.bell_flash_style & 1) ||  // 1: edges only
                          !i || !j || (i == term.rows - 1) || (j == term.cols - 1)
                        );
 
-      if (flashchar)
-        tattr.attr ^= ATTR_REVERSE;
+      if (flashchar) {
+        int style_alt_bg = cfg.bell_flash_style & (2 | 4);  // else inverse
+
+        if (!style_alt_bg)
+          tattr.attr ^= ATTR_REVERSE;
+
+        // The goal below: modify the background color a little ("nudge it",
+        //   typically towards lower contrast against the fg), such that it's
+        //   noticably different - but not as jarring as inverse.
+        //
+        // Preferably we would only touch attributes at tattr.attr, however,
+        // none of them (ATTR_BOLD etc) affect only the background.
+        //
+        // Alternatively, we'll only touch attributes inside ATTR_BGMASK,
+        // however, for the most part it's not bit based but rather indexed
+        // (sort of exceptions are 0-15 and [BOLD_]{FG,BG}_COLOUR_I).
+        //
+        // So we'd have to handle it differently according to the index, e.g.
+        // if <16 then ^8, else if <232 then +/- 43, else if <256 then +/- ~2,
+        // else if !TRUE_COLOR then <do whatever with the default FG/BG/etc>,
+        // else (TRUE_COLOR) nudge the true color up/down.
+        //
+        // Instead of that huge madness, we can do one of two lesser ones:
+        // - Find a way to "massage" the values without having to interpret
+        //   them such that after rendering we get slightly different bg.
+        //   Currently swap bg/fg + inverse + dim seems to do the trick.
+        //   - However, it could change: it's win_text implementation details.
+        // or
+        // - Explicitly turn everything to true color and modify it ourselves.
+        //   That's a similar approach to what wintext.c:brighten(..) does.
+        //   - However, the bg might not necessarily change since win_text can
+        //     shift the color as well, i.e. maybe back to our original value.
+        //     Also, it's not term_paint() mandate to modify explicit colors.
+        //
+        // Both approaches are still too complex, sensitive and hacky, and
+        // neither works well on a fully selected/reversed screen.
+        // Interestingly, together (6, or 7 for edges) seems better. and hackier
+
+        if (style_alt_bg & 2) {
+          // swap the fg/bg (i and true), toggle reverse and dim -> nudges bg.
+          uint bg_i = (tattr.attr & ATTR_BGMASK) >> ATTR_BGSHIFT;
+          uint fg_i = (tattr.attr & ATTR_FGMASK) >> ATTR_FGSHIFT;
+          tattr.attr = (tattr.attr & ~ATTR_BGMASK) | (fg_i << ATTR_BGSHIFT);
+          tattr.attr = (tattr.attr & ~ATTR_FGMASK) | (bg_i << ATTR_FGSHIFT);
+
+          uint tmp = tattr.truebg;
+          tattr.truebg = tattr.truefg;
+          tattr.truefg = tmp;
+
+          tattr.attr ^= ATTR_REVERSE;
+          tattr.attr ^= ATTR_DIM;
+        }
+
+        if (style_alt_bg & 4) {
+          // [convert to true bg,] nudge truebg (typically less contrast).
+          int bg_i = (tattr.attr & ATTR_BGMASK) >> ATTR_BGSHIFT;
+          uint bg = (bg_i >= TRUE_COLOUR) ? tattr.truebg : colours[bg_i];
+          tattr.attr |= TRUE_COLOUR << ATTR_BGSHIFT;  // force truebg
+          if (red(bg) + green(bg) + blue(bg) < 127 * 3) {  // good enough
+            tattr.truebg = make_colour(  // brighten
+              min(255, 20 + red(bg)),
+              min(255, 20 + green(bg)),
+              min(255, 20 + blue(bg))
+            );
+          } else {
+            tattr.truebg = make_colour(  // darken
+              max(0, -30 + red(bg)),
+              max(0, -30 + green(bg)),
+              max(0, -30 + blue(bg))
+            );
+          }
+        }
+      }  // flashchar
 
       int match = in_results(scrpos);
       if (match > 0) {


### PR DESCRIPTION
Flashing the whole window can be a bit jarring. This commit adds an
option for alternative rendering of flashing only the window's edges,
by setting BellFlashIsEdge=yes (no GUI, default is no).

---

I wasn't sure if `docs/mintty.1.html` should be edited manually, but it wasn't generated after modifying `docs/mintty.1` and `make`, so I ended up editing the html file manually.

I don't feel strongly about the names or the docs so I don't mind changing stuff if there are better suggestions, but the feature itself is a useful IMHO.