### PR TITLE
std.h/std.c: added the ARGZ_INTERNAL_IMPL macro for non-cygwin targets.

### DIFF
--- a/src/std.c
+++ b/src/std.c
@@ -86,7 +86,7 @@ int iswspace(wint_t wc) { return wc < 0x100 && isspace(wc); }
 #endif
 
 
-#if CYGWIN_VERSION_API_MINOR < 91
+#if (CYGWIN_VERSION_API_MINOR < 91) || (ARGZ_INTERNAL_IMPL)
 
 /* Copyright (C) 2002 by Red Hat, Incorporated. All rights reserved.
  *

--- a/src/std.h
+++ b/src/std.h
@@ -8,6 +8,10 @@
 #define CYGWIN_VERSION_API_MINOR 201
 #endif
 
+#ifndef ARGZ_INTERNAL_IMPL
+#define ARGZ_INTERNAL_IMPL 0
+#endif
+
 //unhide some definitions
 #define _GNU_SOURCE
 
@@ -42,7 +46,7 @@ static inline void delete(const void *p) { free((void *)p); }
 extern char * tmpdir(void);
 
 
-#if CYGWIN_VERSION_API_MINOR >= 91
+#if (CYGWIN_VERSION_API_MINOR >= 91) && (!ARGZ_INTERNAL_IMPL)
 #include <argz.h>
 #else
 extern int argz_create (char *const argv[], char **argz, size_t *argz_len);


### PR DESCRIPTION
At the present, mintty defines CYGWIN_VERSION_API_MINOR as 1007 for non-cygwin targets. While this measure solves many of the portability issues, it does not account for targets which do not provide (the non-standard) argz.h. The current patch retains the default behavior for cygwin builds while allowing also non-cygwin builds to succeed.
