### PR TITLE
charset.h, charset.c: midipix-specific code paths are now handled extternally

### DIFF
--- a/src/charset.c
+++ b/src/charset.c
@@ -640,7 +640,7 @@ cs_btowc_glyph(char c)
   return wc;
 }
 
-#if defined(__midipix__) || defined(debug_wcs)
+#if defined(debug_wcs)
 
 unsigned int
 wcslen(const wchar * s)
@@ -666,7 +666,7 @@ wcscmp(const wchar * s1, const wchar * s2)
 
 #endif
 
-#if CYGWIN_VERSION_API_MINOR < 74 || defined(__midipix__) || defined(debug_wcs)
+#if CYGWIN_VERSION_API_MINOR < 74 || defined(debug_wcs)
 // needed for MinGW MSYS
 
 wchar *
@@ -716,7 +716,7 @@ wcsncpy(wchar * s1, const wchar * s2, int len)
 
 #endif
 
-#if CYGWIN_VERSION_API_MINOR < 207 || defined(__midipix__) || defined(debug_wcs)
+#if CYGWIN_VERSION_API_MINOR < 207 || defined(debug_wcs)
 
 wchar *
 wcsdup(const wchar * s)
@@ -839,9 +839,5 @@ path_posix_to_win_a(const char * p)
 }
 
 # endif
-#else
-
-#warning port to midipix...
 
 #endif
-

--- a/src/charset.h
+++ b/src/charset.h
@@ -85,8 +85,7 @@ extern char * path_posix_to_win_a(const char * p);
 
 #define dont_debug_wcs
 
-#if defined(__midipix__) || defined(debug_wcs)
-//__midipix__
+#if defined(debug_wcs)
 #define wcslen _wcslen
 #define wcscmp _wcscmp
 //CYGWIN_VERSION_API_MINOR < 74
@@ -98,14 +97,14 @@ extern char * path_posix_to_win_a(const char * p);
 #define wcsdup _wcsdup
 #endif
 
-#if defined(__midipix__) || defined(debug_wcs)
+#if defined(debug_wcs)
 
 extern unsigned int wcslen(const wchar * s);
 extern int wcscmp(const wchar * s1, const wchar * s2);
 
 #endif
 
-#if CYGWIN_VERSION_API_MINOR < 74 || defined(__midipix__) || defined(debug_wcs)
+#if CYGWIN_VERSION_API_MINOR < 74 || defined(debug_wcs)
 // needed for MinGW MSYS
 
 #define wcscpy(tgt, src) memcpy(tgt, src, (wcslen(src) + 1) * sizeof(wchar))
@@ -117,7 +116,7 @@ extern wchar * wcsncpy(wchar * s1, const wchar * s2, int len);
 
 #endif
 
-#if CYGWIN_VERSION_API_MINOR < 207 || defined(__midipix__) || defined(debug_wcs)
+#if CYGWIN_VERSION_API_MINOR < 207 || defined(debug_wcs)
 
 extern wchar * wcsdup(const wchar * s);
 


### PR DESCRIPTION
The previous mintty maintainer anticipated midipix-specific code paths in charset.h and charset.c, and added framework-specific tests accordingly. At the present, these tests are not only wrong, but also stand in the way of the current approach to porting mintty to midipix (using an external build system and avoiding any and all hard-to-maintain, midipix-specific code paths in the upstream mintty source tree). The current patch removes the above tests from chatset.c and charset.h.
