### PR TITLE
Improve bold configuration, improve dim behavior

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -1183,34 +1183,7 @@ term_paint(void)
         if (cfg.bell_flash_style & FLASH_REVERSE)
           tattr.attr ^= ATTR_REVERSE;
         else {
-          colour_i bgi = (tattr.attr & ATTR_BGMASK) >> ATTR_BGSHIFT;
-          if (term.rvideo) {
-            if (bgi >= 256)
-              bgi ^= 2;
-          }
-          colour bg = bgi >= TRUE_COLOUR ? tattr.truebg : colours[bgi];
-
-          colour_i fgi = (tattr.attr & ATTR_FGMASK) >> ATTR_FGSHIFT;
-          if (term.rvideo) {
-            if (fgi >= 256)
-              fgi ^= 2;
-          }
-          if (tattr.attr & ATTR_BOLD && cfg.bold_as_colour) {
-            if (fgi < 8) {
-              fgi |= 8;
-            }
-            else if (fgi >= 256 && fgi != TRUE_COLOUR && !cfg.bold_as_font) {
-              fgi |= 1;
-            }
-          }
-          colour fg = fgi >= TRUE_COLOUR ? tattr.truefg : colours[fgi];
-          if (tattr.attr & ATTR_DIM) {
-            fg = (fg & 0xFEFEFEFE) >> 1;
-            if (!cfg.bold_as_colour || fgi >= 256)
-              fg += (bg & 0xFEFEFEFE) >> 1;
-          }
-
-          tattr.truebg = brighten(bg, fg);
+          tattr.truebg = apply_attr_colour(tattr, ACM_VBELL_BG).truebg;
           tattr.attr = (tattr.attr & ~ATTR_BGMASK) | (TRUE_COLOUR << ATTR_BGSHIFT);
         }
       }

--- a/src/term.h
+++ b/src/term.h
@@ -60,6 +60,9 @@ typedef enum {
   TRUE_COLOUR = 0x180
 } colour_i;
 
+// colour classes
+#define CCL_ANSI8(i) ((i) < 8)
+#define CCL_DEFAULT(i) ((i) >= FG_COLOUR_I && (i) <= BOLD_BG_COLOUR_I)
 
 /* Special Characters:
  * UCSWIDE is a special value used in the terminal data to signify

--- a/src/term.h
+++ b/src/term.h
@@ -157,8 +157,10 @@ enum {
   ATTR_DEFAULT = ATTR_DEFFG | ATTR_DEFBG,
 };
 
+typedef unsigned long long cattrflags;
+
 typedef struct {
-  unsigned long long attr;
+  cattrflags attr;
   uint truefg;
   uint truebg;
 } cattr;

--- a/src/termline.c
+++ b/src/termline.c
@@ -242,7 +242,7 @@ makeliteral_attr(struct buf *b, termchar *c)
   * ensures that attribute values remain 16-bit _unless_ the
   * user uses extended colour.
   */
-  unsigned long long attr = c->attr.attr & ~DATTR_MASK;
+  cattrflags attr = c->attr.attr & ~DATTR_MASK;
   uint truefg = c->attr.truefg;
   uint truebg = c->attr.truebg;
 
@@ -314,7 +314,7 @@ readliteral_chr(struct buf *buf, termchar *c, termline *unused(line))
 static void
 readliteral_attr(struct buf *b, termchar *c, termline *unused(line))
 {
-  unsigned long long attr;
+  cattrflags attr;
   uint fg = 0;
   uint bg = 0;
 

--- a/src/termout.c
+++ b/src/termout.c
@@ -1567,8 +1567,8 @@ do_dcs(void)
 
     otherwise:
       /* parser status initialization */
-      fg = win_get_colour(term.rvideo ? BG_COLOUR_I: FG_COLOUR_I);
-      bg = win_get_colour(term.rvideo ? FG_COLOUR_I: BG_COLOUR_I);
+      fg = win_get_colour(FG_COLOUR_I);
+      bg = win_get_colour(BG_COLOUR_I);
       if (!st) {
         st = term.imgs.parser_state = calloc(1, sizeof(sixel_state_t));
         sixel_parser_set_default_color(st);
@@ -1700,7 +1700,7 @@ do_colour_osc(bool has_index_arg, uint i, bool reset)
     child_printf("\e]%u;", term.cmd_num);
     if (has_index_arg)
       child_printf("%u;", i);
-    c = win_get_colour(i);
+    c = i < COLOUR_NUM ? colours[i] : 0;  // should not be affected by rvideo
     child_printf("rgb:%04x/%04x/%04x\e\\",
                  red(c) * 0x101, green(c) * 0x101, blue(c) * 0x101);
   }

--- a/src/termout.c
+++ b/src/termout.c
@@ -630,7 +630,7 @@ do_sgr(void)
           uchar arg_10 = term.csi_argv[i] - 10;
           if (arg_10 && *cfg.fontfams[arg_10].name) {
             attr.attr &= ~FONTFAM_MASK;
-            attr.attr |= (unsigned long long)arg_10 << ATTR_FONTFAM_SHIFT;
+            attr.attr |= (cattrflags)arg_10 << ATTR_FONTFAM_SHIFT;
           }
           else {
             if (!arg_10)
@@ -641,7 +641,7 @@ do_sgr(void)
         }
       when 12 ... 20:
         attr.attr &= ~FONTFAM_MASK;
-        attr.attr |= (unsigned long long)(term.csi_argv[i] - 10) << ATTR_FONTFAM_SHIFT;
+        attr.attr |= (cattrflags)(term.csi_argv[i] - 10) << ATTR_FONTFAM_SHIFT;
       //when 21: attr.attr &= ~ATTR_BOLD;
       when 21: attr.attr |= ATTR_DOUBLYUND;
       when 22: attr.attr &= ~(ATTR_BOLD | ATTR_DIM);
@@ -2037,7 +2037,7 @@ term_write(const char *buf, uint len)
           continue;
         }
 
-        unsigned long long asav = term.curs.attr.attr;
+        cattrflags asav = term.curs.attr.attr;
 
         // Everything else
         int width;
@@ -2094,7 +2094,7 @@ term_write(const char *buf, uint len)
                   0, 0, 0, 0, 0, 0
                 };
                 uchar dispcode = linedraw_code[wc - 0x60];
-                term.curs.attr.attr |= ((unsigned long long)dispcode) << ATTR_GRAPH_SHIFT;
+                term.curs.attr.attr |= ((cattrflags)dispcode) << ATTR_GRAPH_SHIFT;
               }
 #endif
               wc = dispwc;
@@ -2115,7 +2115,7 @@ term_write(const char *buf, uint len)
                   0x81, 0x82, 0, 0, 0x85, 0x86, 0x87  // sum segments
                 };
                 uchar dispcode = techdraw_code[c - 0x21];
-                term.curs.attr.attr |= ((unsigned long long)dispcode) << ATTR_GRAPH_SHIFT;
+                term.curs.attr.attr |= ((cattrflags)dispcode) << ATTR_GRAPH_SHIFT;
               }
             }
           when CSET_GBCHR:  // NRC United Kingdom

--- a/src/win.h
+++ b/src/win.h
@@ -92,4 +92,14 @@ extern wchar win_combine_chars(wchar bc, wchar cc);
 
 extern wchar win_linedraw_char(int i);
 
+typedef enum {
+    ACM_TERM = 1,        /* actual terminal rendering */
+    ACM_RTF_PALETTE = 2, /* winclip - rtf palette setup stage */
+    ACM_RTF_GEN = 4,     /* winclip - rtf generation stage */
+    ACM_SIMPLE = 8,      /* simplified (for truecolour(...) ) */
+    ACM_VBELL_BG = 16,   /* visual-bell background highlight */
+} attr_colour_mode;
+
+extern cattr apply_attr_colour(cattr a, attr_colour_mode mode);
+
 #endif

--- a/src/winclip.c
+++ b/src/winclip.c
@@ -207,9 +207,9 @@ apply_attr_colour_rtf(cattrflags a, attr_colour_mode mode, int * pfgi, int * pbg
   cattr ca = apply_attr_colour((cattr){ .attr = a }, mode);
   *pfgi = (ca.attr & ATTR_FGMASK) >> ATTR_FGSHIFT;
   *pbgi = (ca.attr & ATTR_BGMASK) >> ATTR_BGSHIFT;
-  // In ACM_RTF_GEN mode, COLOUR_NUM communicates "no-colour" (-1)
-  if (*pfgi == COLOUR_NUM && mode == ACM_RTF_GEN) *pfgi = -1;
-  if (*pbgi == COLOUR_NUM && mode == ACM_RTF_GEN) *pbgi = -1;
+  // true colour breaks both, and ACM_RTF_GEN needs COLOUR_NUM as -1 (no colour)
+  if (*pfgi >= COLOUR_NUM) *pfgi = (mode == ACM_RTF_GEN) ? -1 : FG_COLOUR_I;
+  if (*pbgi >= COLOUR_NUM) *pbgi = (mode == ACM_RTF_GEN) ? -1 : BG_COLOUR_I;
   return ca.attr;
 }
 

--- a/src/wintext.c
+++ b/src/wintext.c
@@ -1401,7 +1401,6 @@ cattr
 apply_attr_colour(cattr a, attr_colour_mode mode)
 {
   // indexed modifications
-  bool do_rvideo_i = mode & (ACM_TERM | ACM_SIMPLE | ACM_VBELL_BG);
   bool do_reverse_i = mode & (ACM_RTF_PALETTE | ACM_RTF_GEN);
   bool do_bold_i = mode & (ACM_TERM | ACM_RTF_PALETTE | ACM_RTF_GEN | ACM_SIMPLE | ACM_VBELL_BG);
   bool do_blink_i = mode & (ACM_TERM | ACM_RTF_PALETTE | ACM_RTF_GEN);
@@ -1411,13 +1410,6 @@ apply_attr_colour(cattr a, attr_colour_mode mode)
   colour_i fgi = (a.attr & ATTR_FGMASK) >> ATTR_FGSHIFT;
   colour_i bgi = (a.attr & ATTR_BGMASK) >> ATTR_BGSHIFT;
   a.attr &= ~(ATTR_FGMASK | ATTR_BGMASK);  // we'll refill it later
-
-  if (do_rvideo_i && term.rvideo) {
-    if (CCL_DEFAULT(fgi))
-      fgi ^= 2;     // (BOLD_)?FG_COLOUR_I <-> (BOLD_)?BG_COLOUR_I
-    if (CCL_DEFAULT(bgi))
-      bgi ^= 2;     // (BOLD_)?FG_COLOUR_I <-> (BOLD_)?BG_COLOUR_I
-  }
 
   if (do_reverse_i && (a.attr & ATTR_REVERSE)) {
     colour_i t = fgi; fgi = bgi; bgi = t;
@@ -2428,6 +2420,8 @@ static bool bold_colour_selected = false;
 
 colour win_get_colour(colour_i i)
 {
+  if (term.rvideo && CCL_DEFAULT(i))
+    return colours[i ^ 2];  // [BOLD]_FG_COLOUR_I  <-->  [BOLD]_BG_COLOUR_I
   return i < COLOUR_NUM ? colours[i] : 0;
 }
 

--- a/src/wintext.c
+++ b/src/wintext.c
@@ -1343,6 +1343,147 @@ text_out_end()
     ScriptStringFree(&ssa);
 }
 
+
+// applies bold as colour if required, returns true if still needs thickening
+static bool
+apply_bold_colour(colour_i *pfgi)
+{
+  // We use two bits to control colouring and thickening for three classes of
+  // colours: ANSI (0-7), default, and other (8-256, true). We also reserve one
+  // combination for xterm's default (thicken everything, ANSI is also coloured).
+  // - "other" is always thickened and never gets colouring.
+  // - when bold_as_colour=no: ANSI+defaut are only thickened.
+  // - when bold_as_colour=yes:
+  //   .. and bold_as_font=no:  ANSI+default are only coloured
+  //   .. and bold_as_font=yes: ANSI+default are thickened, ANSI also coloured (xterm)
+  if (cfg.bold_as_colour) {
+    if (CCL_ANSI8(*pfgi)) {
+      *pfgi |= 8;     // (BLACK|...|WHITE)_I -> BOLD_(BLACK|...|WHITE)_I
+      return cfg.bold_as_font;
+    }
+    if (CCL_DEFAULT(*pfgi) && !cfg.bold_as_font) {
+      *pfgi |= 1;     // (FG|BG)_COLOUR_I -> BOLD_(FG|BG)_COLOUR_I
+      return false;
+    }
+  }
+  return true;
+}
+
+// removes default colours if not reversed, returns true if still needs thickening
+static bool
+rtf_bold_decolour(cattrflags attr, colour_i * pfgi, colour_i * pbgi)
+{
+  bool bold_thickens = cfg.bold_as_font;  // all colours
+  // if not reverse:
+  // - if only bold_as_colour, ATTR_BOLD still thickens default fg on default bg
+  // - don't colour default fg/bg (caller interprets COLOUR_NUM as "no colour").
+  if (!(attr & ATTR_REVERSE)) {
+    if (cfg.bold_as_colour && CCL_DEFAULT(*pfgi) && CCL_DEFAULT(*pbgi))
+      bold_thickens = true;  // even if bold_as_font=no
+    if (CCL_DEFAULT(*pfgi))
+      *pfgi = COLOUR_NUM;  // no colouring
+    if (CCL_DEFAULT(*pbgi))
+      *pbgi = COLOUR_NUM;  // no colouring
+  }
+  return (attr & ATTR_BOLD) && bold_thickens;
+}
+
+// Applies attributes to the fg/bg colours and returns the new cattr.
+//
+// "mode" maps to arbitrary sets of "things to do". Mostly these are just
+// groups of attributes to handle, but it may also reflect custom needs.
+//
+// While {FG|BG}MASK and truefg/truebg might update, attributes remain the same.
+// The exception is bold which can be applied as colour and/or thickness,
+// so ATTR_BOLD bit will be turned off if further thickening should not happen.
+// Always returns true colour, except ACM_RTF* modes which only do the palette.
+cattr
+apply_attr_colour(cattr a, attr_colour_mode mode)
+{
+  // indexed modifications
+  bool do_rvideo_i = mode & (ACM_TERM | ACM_SIMPLE | ACM_VBELL_BG);
+  bool do_reverse_i = mode & (ACM_RTF_PALETTE | ACM_RTF_GEN);
+  bool do_bold_i = mode & (ACM_TERM | ACM_RTF_PALETTE | ACM_RTF_GEN | ACM_SIMPLE | ACM_VBELL_BG);
+  bool do_blink_i = mode & (ACM_TERM | ACM_RTF_PALETTE | ACM_RTF_GEN);
+  bool do_finalize_rtf_i = mode & (ACM_RTF_PALETTE | ACM_RTF_GEN);
+  bool do_rtf_bold_decolour_i = mode & (ACM_RTF_GEN);
+
+  colour_i fgi = (a.attr & ATTR_FGMASK) >> ATTR_FGSHIFT;
+  colour_i bgi = (a.attr & ATTR_BGMASK) >> ATTR_BGSHIFT;
+  a.attr &= ~(ATTR_FGMASK | ATTR_BGMASK);  // we'll refill it later
+
+  if (do_rvideo_i && term.rvideo) {
+    if (CCL_DEFAULT(fgi))
+      fgi ^= 2;     // (BOLD_)?FG_COLOUR_I <-> (BOLD_)?BG_COLOUR_I
+    if (CCL_DEFAULT(bgi))
+      bgi ^= 2;     // (BOLD_)?FG_COLOUR_I <-> (BOLD_)?BG_COLOUR_I
+  }
+
+  if (do_reverse_i && (a.attr & ATTR_REVERSE)) {
+    colour_i t = fgi; fgi = bgi; bgi = t;
+  }
+
+  bool reset_bold = false;
+  if (do_bold_i && (a.attr & ATTR_BOLD))    // rtf_bold_decolour uses ATTR_BOLD
+    reset_bold = !apply_bold_colour(&fgi);  // we'll reset afterwards if needed
+
+  if (do_blink_i && (a.attr & ATTR_BLINK)) {
+    if (CCL_ANSI8(bgi))
+      bgi |= 8;
+    else if (CCL_DEFAULT(bgi))
+      bgi |= 1;
+  }
+
+  if (do_finalize_rtf_i) {
+    if (do_rtf_bold_decolour_i) {  // uses ATTR_BOLD, ATTR_REVERSE
+      bool thicken = rtf_bold_decolour(a.attr, &fgi, &bgi);
+      if (!thicken)
+        a.attr &= ~ATTR_BOLD;
+    }
+
+    if (a.attr & ATTR_INVISIBLE)
+      fgi = bgi;
+
+    a.attr |= fgi << ATTR_FGSHIFT | bgi << ATTR_BGSHIFT;
+    return a;  // rtf colouring ignores true colours
+  }
+
+  if (reset_bold)
+    a.attr &= ~ATTR_BOLD;  // off if we should not further thicken
+
+  // from here onward the result is true colour
+  bool do_dim = mode & (ACM_TERM | ACM_SIMPLE | ACM_VBELL_BG);
+  bool do_reverse = mode & (ACM_TERM);
+  bool do_invisible = mode & (ACM_TERM | ACM_SIMPLE);
+  bool do_vbell_bg = mode & (ACM_VBELL_BG);
+
+  colour fg = fgi >= TRUE_COLOUR ? a.truefg : win_get_colour(fgi);
+  colour bg = bgi >= TRUE_COLOUR ? a.truebg : win_get_colour(bgi);
+
+  if (do_dim && (a.attr & ATTR_DIM)) {
+    fg = (fg & 0xFEFEFEFE) >> 1; // Halve the brightness.
+    if (!cfg.bold_as_colour || fgi >= 256)
+      fg += (bg & 0xFEFEFEFE) >> 1; // Blend with background.
+  }
+
+  if (do_reverse && (a.attr & ATTR_REVERSE)) {
+    colour t = fg; fg = bg; bg = t;
+  }
+
+  if (do_invisible && (a.attr & ATTR_INVISIBLE))
+    fg = bg;
+
+  if (do_vbell_bg)  // FIXME: we should have TATTR_VBELL. selection should too
+    bg = brighten(bg, fg);
+
+  // ACM_TERM does also search and cursor colours. for now we don't handle those
+
+  a.truefg = fg;
+  a.truebg = bg;
+  a.attr |= TRUE_COLOUR << ATTR_FGSHIFT | TRUE_COLOUR << ATTR_BGSHIFT;
+  return a;
+}
+
 /*
  * Extract colour value from attribute;
  * simplified version of the algorithm below.
@@ -1350,30 +1491,10 @@ text_out_end()
 colour
 truecolour(cattr * pattr, colour bg)
 {
-  colour_i fgi = (pattr->attr & ATTR_FGMASK) >> ATTR_FGSHIFT;
-  if (term.rvideo) {
-    if (fgi >= 256)
-      fgi ^= 2;     // (BOLD_)?FG_COLOUR_I <-> (BOLD_)?BG_COLOUR_I
-  }
-  if (pattr->attr & ATTR_BOLD && cfg.bold_as_colour) {
-    if (fgi < 8) {
-      fgi |= 8;     // (BLACK|...|WHITE)_I -> BOLD_(BLACK|...|WHITE)_I
-    }
-    else if (fgi >= 256 && fgi != TRUE_COLOUR && !cfg.bold_as_font) {
-      fgi |= 1;     // (FG|BG)_COLOUR_I -> BOLD_(FG|BG)_COLOUR_I
-    }
-  }
-
-  colour fg = fgi >= TRUE_COLOUR ? pattr->truefg : colours[fgi];
-  if (pattr->attr & ATTR_DIM) {
-    fg = (fg & 0xFEFEFEFE) >> 1; // Halve the brightness.
-    if (!cfg.bold_as_colour || fgi >= 256)
-      fg += (bg & 0xFEFEFEFE) >> 1; // Blend with background.
-  }
-  if (pattr->attr & ATTR_INVISIBLE)
-    fg = bg;
-
-  return fg;
+  return apply_attr_colour(
+    (cattr){ .attr = pattr->attr, .truefg = pattr->truefg, .truebg = bg },
+    ACM_SIMPLE
+  ).truefg;
 }
 
 /*
@@ -1450,58 +1571,10 @@ win_text(int x, int y, wchar *text, int len, cattr attr, cattr *textattr, ushort
   if (!ff->fonts[nfont])
     nfont = FONT_NORMAL;
 
-  colour_i fgi = (attr.attr & ATTR_FGMASK) >> ATTR_FGSHIFT;
-  colour_i bgi = (attr.attr & ATTR_BGMASK) >> ATTR_BGSHIFT;
-
-  bool apply_shadow = true;
-  if (term.rvideo) {
-    if (fgi >= 256)
-      fgi ^= 2;     // (BOLD_)?FG_COLOUR_I <-> (BOLD_)?BG_COLOUR_I
-    if (bgi >= 256)
-      bgi ^= 2;     // (BOLD_)?FG_COLOUR_I <-> (BOLD_)?BG_COLOUR_I
-  }
-  if (attr.attr & ATTR_BOLD && cfg.bold_as_colour) {
-    if (fgi < 8) {
-      if (!cfg.bold_as_font)
-        apply_shadow = false;
-#ifdef debug_bold
-      printf("fgi < 8 (%d %d): apply_shadow %d\n", (int)colours[fgi], (int)colours[fgi | 8], apply_shadow);
-#endif
-#ifdef enforce_bold
-      if (colours[fgi] == colours[fgi | 8])
-        apply_shadow = true;
-#endif
-      fgi |= 8;     // (BLACK|...|WHITE)_I -> BOLD_(BLACK|...|WHITE)_I
-    }
-    else if (fgi >= 256 && fgi != TRUE_COLOUR && !cfg.bold_as_font) {
-      apply_shadow = false;
-#ifdef enforce_bold
-      if (colours[fgi] == colours[fgi | 1])
-        apply_shadow = true;
-#endif
-      fgi |= 1;     // (FG|BG)_COLOUR_I -> BOLD_(FG|BG)_COLOUR_I
-    }
-  }
-  if (attr.attr & ATTR_BLINK) {
-    if (bgi < 8)
-      bgi |= 8;
-    else if (bgi >= 256)
-      bgi |= 1;
-  }
-
-  colour fg = fgi >= TRUE_COLOUR ? attr.truefg : colours[fgi];
-  colour bg = bgi >= TRUE_COLOUR ? attr.truebg : colours[bgi];
-
-  if (attr.attr & ATTR_DIM) {
-    fg = (fg & 0xFEFEFEFE) >> 1; // Halve the brightness.
-    if (!cfg.bold_as_colour || fgi >= 256)
-      fg += (bg & 0xFEFEFEFE) >> 1; // Blend with background.
-  }
-  if (attr.attr & ATTR_REVERSE) {
-    colour t = fg; fg = bg; bg = t;
-  }
-  if (attr.attr & ATTR_INVISIBLE)
-    fg = bg;
+  attr = apply_attr_colour(attr, ACM_TERM);
+  colour fg = attr.truefg;
+  colour bg = attr.truebg;
+  // ATTR_BOLD is now set if and only if we need further thickening.
 
   bool has_cursor = attr.attr & (TATTR_ACTCURS | TATTR_PASCURS);
   colour cursor_colour = 0;
@@ -1688,7 +1761,7 @@ win_text(int x, int y, wchar *text, int len, cattr attr, cattr *textattr, ushort
 
  /* Determine shadow/overstrike bold or double-width/height width */
   int xwidth = 1;
-  if (apply_shadow && ff->bold_mode == BOLD_SHADOW && (attr.attr & ATTR_BOLD)) {
+  if (ff->bold_mode == BOLD_SHADOW && (attr.attr & ATTR_BOLD)) {
     // This could be scaled with font size, but at risk of clipping
     xwidth = 2;
     if (lattr != LATTR_NORM) {


### PR DESCRIPTION
(let me know if you want to split this PR)

Initially I only wanted to improve the bold font/colour/shadow control. I did
end up doing that, and these are the last two commits.

This is how BoldAsFont and BoldAsColour affect ANSI/default colours:
```
AsFont  AsColour  Previously                Now
------  --------  ------------------------  --------------------------------
no      yes       both only colour          both only colour (same, default)
yes     no        both only thick           both only thick (same)
yes     yes       both thick, ANSI +colour  both thick+colour (new)
no      no        both only thick           both thick, ANSI +colour (xterm)

Two combinations are the same, xterm-like moved from yes/yes to no/no,
and we now have an additional behaviour where both are thick+colour.

We also have the new BoldThickenForcesShadow to choose thick = font/shadow,
which defaults to font and is unaffected by the GUI checkboxes.
```

However, before I got there, I realized that the BoldAsFont/BoldAsColour logic
is duplicated 5 times around the code, that BoldAsColour also affects the
dim behavior, that the dim/BoldAsColour logic is duplicated 3 times, and that
there are few more similar duplications.

I could have duplicated my changes to all these places, or modify just enough
for the normal terminal rendering to be affected, but I chose instead to unify
all those duplicates of attributes-to-colours such that it's easy to modify in
the future as well.

So the unification is the first 3 commits and, except for new bugs, these 3
commits should keep the behaviour identical(*).

While decoupling BoldAsColour from dim, I also modified the dim behavior
(more info at the commit message):
```
Dim now does two things unconditionally:
- Blend the cell's foreground with the terminal's default background.
- Blend the cell's background with the terminal's default background.
```

(*) almost identical. I noticed a bug when copying true-colour to rtf, and it
was a one line fix. Other than this fix, it should be identical.
