### PR TITLE
fix restore wrong win HWND

### DIFF
--- a/src/winmain.c
+++ b/src/winmain.c
@@ -406,7 +406,7 @@ win_to_top(HWND top_wnd)
   SetForegroundWindow(top_wnd);
   // SetActiveWindow(top_wnd);
 
-  ShowWindow(wnd, SW_RESTORE);
+  ShowWindow(top_wnd, SW_RESTORE);
 }
 
 static HWND first_wnd, last_wnd;


### PR DESCRIPTION
fixed the bug when using sessions switcher, the minimum window can not restore to normal size