### PR TITLE
Pr bold demonstration

### DIFF
--- a/docs/mintty.1
+++ b/docs/mintty.1
@@ -912,21 +912,46 @@ Note that font smoothing may be affected by Windows-generated underline modes.
 
 .TP
 \fBShow bold as font\fP (BoldAsFont=no)
-When this option is enabled, the ANSI bold (or 'intense') text attribute is
-shown as a bold-style font.  Where a bold variant of the selected font that
-has the same width as the base font is available, that is used; otherwise, the
-bolding is simulated by rendering the text twice with a one-pixel offset.
+Display the ANSI bold (or 'intense') text attribute as a bold-style font. Where
+a bold variant of the selected font that has the same width as the base font is
+available, that is used; otherwise, the bolding is simulated by rendering the
+text twice with a one-pixel offset.
+
+This option is not fully independent. See \fBBold Behaviour\fP below.
 
 .TP
 \fBShow bold as colour\fP (BoldAsColour=yes)
-By default, text with the ANSI bold attribute set is displayed with a
-different colour, usually with increased brightness (mapping ANSI colours 
-0..7 to their bright variants 8..15). This can be disabled here.
+Display the bold text attribute with a different colour, usually with increased
+brightness - mapping ANSI colours 0..7 to their bright variants 8..15, and the
+default colour to the value of option \fBBoldColour\fP (or to an automatic
+bright colour if BoldColour is not set, or to the bold colour set by an OSC
+escape sequence).
 
-Note that when \fBBoldAsFont\fP is enabled, only bold text in one of the eight
-ANSI colours has its colour changed, i.e. bold text without an explicitly
-specified colour is shown with a bold font only.  This matches \fBxterm\fP behaviour.
-Note also setting \fBBoldColour\fP.
+This option is not fully independent. See \fBBold Behaviour\fP below.
+
+.TP
+\fBNote: Bold Behaviour\fP
+When the the bold text attribute is set, mintty displays it while
+distinguishing between three classes of colours:
+.br
+\(en \fBANSI8\fP: The ANSI colours 0..7 (used for SGR 30..37).
+.br
+\(en \fBDefault\fP: The default terminal foreground colour (not part of ANSI8).
+.br
+\(en \fBExtended\fP: True colours and the rest of the 256 colours palette.
+.br
+
+The colour classes are affected by the bold text attribute as follows:
+.br
+\(en Extended colours are always shown with a bold font only.
+.br
+\(en When both BoldAsFont and BoldAsColour are disabled, mintty engages a mode
+similar to the xterm default behaviour: ANSI8 is displayed with a bold font and
+a different colour, Default colour only uses a bold font.
+.br
+\(en Otherwise, the ANSI8 colours and the default colour are considered one unit,
+where BoldAsFont and BoldAsColour have independent effect on this unit - such
+that it's possible to choose only bold font, or only different colour, or both.
 
 .TP
 \fBAllow blinking\fP (AllowBlinking=no)


### PR DESCRIPTION
Note: this PR demonstrates the bold config improvements, while knowingly ignoring the behavior of dim, copying to rtf, combined characters, custom selection colours, and visual bell background-highlight style. PR #710 does the same as this PR while taking those into account.

Terminology:
- Bold Font: font variant thicker than the normal font. Sometimes we don't have it or can't use it.
- "Shadow" (same as "overstrike"): emulate bold font using a normal font (redraw with 1px offets to render it thicker). Typically inferior to bold font, but has the advantage that we can always use it.
- "Thick": use bold font if possible, and if not possible then use shadow.

Colour classes:
- "ANSI": the normal 8 ansi colours (0-7).
- "Default": default terminal foreground colour. Not part of the ANSI colours.
- "Other": colours 8-255 and true colours (and search/IME/etc colours too).


Current mintty behavior using the above shadow/thick terminology:
```
     Config      |       Effect on the colour classes        |
---------------- | ------------------------------------------| ----------------
AsColour  AsFont | ANSI             Default         | Other  | Notes
--------  ------ | ---------------  --------------- | ------ | ----------------
no        no     | shadow           shadow          | shadow |
no        yes    | thick            thick           | thick  |
yes       no     | colour           colour          | shadow | default config
yes       yes    | colour + thick   thick           | thick  | xterm compatible
```
Problem 1:
- We should not have "shadow" at the table as it means we force shadow even if we have a suitable bold font. This is an undesirable behavior.

This issue is also affacting the default configuration (yes/no). "other" colours are not rare these days, as many apps support 256 colours or more. Currently bold "other" defaults to shadow even if we have a suitable bold font.

However, sometimes (never?) the user might prefer shadow over bold font.

Solution part 1 (commit `bold config: add ThickenForcesShadow`):
- Turn all "shadow" at the table to "thick" as the default behavior.
- Add a config which can force all "thick" to be "shadow".

Now the behavior is (with the same shadow/thick terminology):

With ThickenForcesShadow=no (the default):
```
AsColour  AsFont | ANSI             Default         | Other  | Notes
--------  ------ | ---------------  --------------- | ------ | ----------------
no        no     | thick            thick           | thick  |
no        yes    | thick            thick           | thick  |
yes       no     | colour           colour          | thick  | default config
yes       yes    | colour + thick   thick           | thick  | xterm compatible
```
And with ThickenForcesShadow=yes :
```
AsColour  AsFont | ANSI             Default         | Other  | Notes
--------  ------ | ---------------  --------------- | ------ | ----------------
no        no     | shadow           shadow          | shadow |
no        yes    | shadow           shadow          | shadow |
yes       no     | colour           colour          | shadow |
yes       yes    | colour + shadow  shadow          | shadow |
```

(We'll assume ThickenForcesShadow=no from now on. It's clear what "yes" would do)

Problem 2:
- The first two rows at the table have identical outcomes. It's a shame to give up quarter of our possible combinations, especially when we're missing a useful one: both ANSI and default are "colour + thick":

Solution part 2:
- Use the first table row to host the missing combination:
```
AsColour  AsFont | ANSI             Default         | Other  | Notes
--------  ------ | ---------------  --------------- | ------ | ----------------
no        no     | colour + thick   colour + thick  | thick  |
no        yes    | thick            thick           | thick  |
yes       no     | colour           colour          | thick  | default config
yes       yes    | colour + thick   thick           | thick  | xterm compatible
```
Problem 3:
- Now we have 4 effective combinations, but the table is even more confusing - the effect of the config values on the outcomes seem random.

Solution part 3 (commit `bold font/colour: improve control` is 2+3):
- Swap the behavior between no/no and yes/yes:
```
AsColour  AsFont |      ANSI            Default     | Other  | Notes
--------  ------ | ---------------  --------------- | ------ | ----------------
no        no     | colour + thick            thick  | thick  | xterm compatible
--------  ------ | ---------------  --------------- | ------ | ----------------
no        yes    |          thick            thick  | thick  |
yes       no     | colour           colour          | thick  | default config
yes       yes    | colour + thick   colour + thick  | thick  |
```

That's better. Except for no/no which is "special" and behaves like xterm, the three other combinations are logical - AsFont and AsColour are independent and have a logical outcome - AsColour only affects colour, AsFont only affects thicker font rendering, and they can be combined logically.

(we're ignoring the fact that we still can't use colour for "other")

Arguably it's also less surprising to have a special no/no than a special yes/yes like we had before.

And of course, the user can still use ThickenForcesShadow=yes to turn all the "thick" at the table into "shadow", while leaving AsColour and AsFont with the same logical outcomes.
