### PR TITLE
Add Ctrl+Alt+Click window movement.

### DIFF
--- a/src/winmain.c
+++ b/src/winmain.c
@@ -2196,7 +2196,16 @@ static struct {
       break;
 #endif
     }
-  }
+
+    when WM_NCHITTEST: {
+      LRESULT result = DefWindowProcW(wnd, message, wp, lp);
+
+      if (result == HTCLIENT &&
+          (GetKeyState(VK_MENU) & 0x80) && (GetKeyState(VK_CONTROL) & 0x80))
+        return HTCAPTION;
+      else
+        return result;
+    }
 
  /*
   * Any messages we don't process completely above are passed through to


### PR DESCRIPTION
In reference to #729; the window style chosen with `-B frame` allows no movement at all. The `Alt+Click` functionality works regardless of border style.

The code works by telling the desktop that the client area is actually the title bar.

If necessary I can work on adding the modifier to the options dialog. Where should it go? For Windows, any keys besides `Alt` may prove problematic due to unconfigurable UI behavior. `Shift` is also popular.