### PR TITLE
Add basic support for per-window DPI awareness v2, remove window flutter

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -165,7 +165,7 @@ typedef struct {
   int geom_sync;
   int col_spacing, row_spacing;
   int padding;
-  bool handle_dpichanged;
+  int handle_dpichanged;
   int check_version_update;
   string word_chars;
   string word_chars_excl;

--- a/src/winpriv.h
+++ b/src/winpriv.h
@@ -38,7 +38,7 @@ extern wstring wsl_basepath;
 extern bool win_is_fullscreen;
 extern bool clipboard_token;
 extern uint dpi;
-extern bool per_monitor_dpi_aware;
+extern int per_monitor_dpi_aware;
 
 extern bool click_focus_token;
 


### PR DESCRIPTION
This change adds basic support for per-window DPI awareness v2, introduced with Windows 10 1703.
In the long run, this enables mintty to use WM_GETDPISCALEDSIZE to resize the window pixel-perfectly when the pixel density changes so that the terminal's size in rows×cols stays constant.

For the moment, the basic support gets rid of mintty's window flipping back and forth between different screens A↔B if I drag it from a screen A onto a screen B with a different pixel density.