### PR TITLE
add .editorconfig with whitespace trimming disabled

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Alternative to https://github.com/mintty/mintty/pull/792. This configures a user's editor to not trim whitespace in this project. See https://editorconfig.org/ for the other available options.