### PR TITLE
BellInterval directive: quash bells for this many msec after the last

### DIFF
--- a/docs/mintty.1
+++ b/docs/mintty.1
@@ -1712,7 +1712,9 @@ switchable by an escape sequence.)
 \(en \fBPopup on bell\fP (BellPopup=no): Popup mintty to desktop foreground.
 (Corresponds to the xterm resource \fBpopOnBell\fP, 
 switchable by an escape sequence.)
-
+.br
+\(en \fBMinimum delay between bells\fP (BellInterval=100): Multiple bells within this many milliseconds will sound as one.
+.br
 A simple \fBfrequency beep\fP can be configured in the configuration file 
 or on the command line:
 .br

--- a/docs/mintty.1
+++ b/docs/mintty.1
@@ -1715,6 +1715,7 @@ switchable by an escape sequence.)
 .br
 \(en \fBMinimum delay between bells\fP (BellInterval=100): Multiple bells within this many milliseconds will sound as one.
 .br
+
 A simple \fBfrequency beep\fP can be configured in the configuration file 
 or on the command line:
 .br

--- a/docs/mintty.1.html
+++ b/docs/mintty.1.html
@@ -2154,6 +2154,10 @@ active. (Corresponds to the xterm resource
 desktop foreground. (Corresponds to the xterm resource
 <b>popOnBell</b>, switchable by an escape sequence.)</p>
 
+<p style="margin-left:22%;">&ndash; <b>Minimum delay
+between bells</b> (BellInterval=100): Multiple bells 
+within this many milliseconds will sound as one.</p>
+
 <p style="margin-left:22%; margin-top: 1em">A simple
 <b>frequency beep</b> can be configured in the configuration
 file or on the command line: <br>

--- a/src/config.c
+++ b/src/config.c
@@ -136,6 +136,7 @@ const config default_cfg = {
   .bell_flash_style = FLASH_FULL,
   .bell_taskbar = true, // xterm: bellIsUrgent
   .bell_popup = false,  // xterm: popOnBell
+  .bell_interval = 100,
   .printer = W(""),
   .confirm_exit = true,
   .allow_set_selection = false,
@@ -371,6 +372,7 @@ options[] = {
   {"BellFlashStyle", OPT_INT, offcfg(bell_flash_style)},
   {"BellTaskbar", OPT_BOOL, offcfg(bell_taskbar)},
   {"BellPopup", OPT_BOOL, offcfg(bell_popup)},
+  {"BellInterval", OPT_INT, offcfg(bell_interval)},
   {"Printer", OPT_WSTRING, offcfg(printer)},
   {"ConfirmExit", OPT_BOOL, offcfg(confirm_exit)},
   {"AllowSetSelection", OPT_BOOL, offcfg(allow_set_selection)},

--- a/src/config.h
+++ b/src/config.h
@@ -134,6 +134,7 @@ typedef struct {
   int bell_flash_style;
   bool bell_taskbar; // xterm: bellIsUrgent
   bool bell_popup;   // xterm: popOnBell
+  int bell_interval;
   wstring printer;
   bool confirm_exit;
   bool allow_set_selection;

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -1550,7 +1550,7 @@ win_bell(config * conf)
          unsigned long now = mtime();
 
   if ( (conf->bell_sound || conf->bell_type) &&
-      ((unsigned long)conf->bell_interval <= now-last_bell) ) {
+      ((unsigned long)conf->bell_interval <= now - last_bell) ) {
     wchar * bell_name = (wchar *)conf->bell_file;
     bool free_bell_name = false;
     last_bell = now;

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -1546,9 +1546,14 @@ flash_border()
 void
 win_bell(config * conf)
 {
-  if (conf->bell_sound || conf->bell_type) {
+  static unsigned long last_bell=0;
+         unsigned long now=mtime();
+
+  if ( (conf->bell_sound || conf->bell_type) &&
+      ((unsigned long)conf->bell_interval <= now-last_bell) ) {
     wchar * bell_name = (wchar *)conf->bell_file;
     bool free_bell_name = false;
+    last_bell=now;
     if (*bell_name) {
       if (wcschr(bell_name, L'/') || wcschr(bell_name, L'\\')) {
         if (bell_name[1] != ':') {

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -1546,14 +1546,14 @@ flash_border()
 void
 win_bell(config * conf)
 {
-  static unsigned long last_bell=0;
-         unsigned long now=mtime();
+  static unsigned long last_bell = 0;
+         unsigned long now = mtime();
 
   if ( (conf->bell_sound || conf->bell_type) &&
       ((unsigned long)conf->bell_interval <= now-last_bell) ) {
     wchar * bell_name = (wchar *)conf->bell_file;
     bool free_bell_name = false;
-    last_bell=now;
+    last_bell = now;
     if (*bell_name) {
       if (wcschr(bell_name, L'/') || wcschr(bell_name, L'\\')) {
         if (bell_name[1] != ':') {


### PR DESCRIPTION
Rapid consecutive bells in mintty can cause a harsh buzzing sound.

The effect is present whether using system sounds, a WAV file, or `BellFreq`/`BellLen`.  You can observe it (well, hear it) with this shell command that produces many bells:  `printf "\a%.0s" {1..100}`  

This short patch adds a config directive, `BellInterval`, which dictates the minimum time, in milliseconds, between bells.  Bells triggered during the post-bell silence period are ignored.

NB: bells are played asynchronously, so this interval includes the duration of the bell itself.  In other words, if the bell sound is itself longer than `BellInterval`, you'll get the old behavior with no guaranteed silence.
