### PR TITLE
added switch(-visible)-next/prev KeyFunctions for switching virtual tabs

### DIFF
--- a/docs/mintty.1
+++ b/docs/mintty.1
@@ -2475,6 +2475,16 @@ Supported actions are described as follows:
 \(en \fBscroll_prev\fP: scroll scrollback view to previous marker
 .br
 \(en \fBscroll_next\fP: scroll scrollback view to next marker
+.br
+
+\(en \fBswitch-prev\fP: switch to previous virtual tab
+.br
+\(en \fBswitch-next\fP: switch to next virtual tab
+.br
+\(en \fBswitch-visible-prev\fP: switch to previous virtual tab which is not iconized
+.br
+\(en \fBswitch-visible-next\fP: switch to next virtual tab which is not iconized
+.br
 
 \fINote (*):\fP The exact behaviour of some actions depends on the 
 state of the Shift key.

--- a/src/wininput.c
+++ b/src/wininput.c
@@ -1229,6 +1229,15 @@ static void scroll_LEFT()
 static void scroll_RIGHT()
   { SendMessage(wnd, WM_VSCROLL, SB_NEXT, 0); }
 
+static void switch_NEXT()
+  { win_switch(false, true); }
+static void switch_PREV()
+  { win_switch(true, true); }
+static void switch_visible_NEXT()
+  { win_switch(false, false); }
+static void switch_visible_PREV()
+  { win_switch(true, false); }
+
 static void
 nop()
 {
@@ -1442,6 +1451,11 @@ static struct function_def cmd_defs[] = {
   {"scroll_lndn", {.fct = scroll_DOWN}, 0},
   {"scroll_prev", {.fct = scroll_LEFT}, 0},
   {"scroll_next", {.fct = scroll_RIGHT}, 0},
+
+  {"switch-prev", {.fct = switch_PREV}, 0},
+  {"switch-next", {.fct = switch_NEXT}, 0},
+  {"switch-visible-prev", {.fct = switch_visible_PREV}, 0},
+  {"switch-visible-next", {.fct = switch_visible_NEXT}, 0},
 
   {"void", {.fct = nop}, 0}
 };


### PR DESCRIPTION
Corresponding code for issue (#923).
Function names are changed to dashes and added `switch-visible-next/prev`. 