### PR TITLE
Enhanced dark mode.

### DIFF
--- a/src/winmain.c
+++ b/src/winmain.c
@@ -183,7 +183,7 @@ trace_winsize(char * tag)
 #define trace_winsize(tag)	
 #endif
 
-static void (WINAPI * pRtlGetNtVersionNumbers)(LPDWORD, LPDWORD, LPDWORD) = 0;
+static void (WINAPI * pRtlGetNtVersionNumbers)(LPDWORD, LPDWORD, LPDWORD) = 0; /* undocumented */
 
 static HRESULT (WINAPI * pDwmIsCompositionEnabled)(BOOL *) = 0;
 static HRESULT (WINAPI * pDwmExtendFrameIntoClientArea)(HWND, const MARGINS *) = 0;
@@ -193,13 +193,13 @@ static HRESULT (WINAPI * pDwmSetWindowAttribute)(HWND, DWORD, LPCVOID, DWORD) = 
 static HRESULT (WINAPI * pSetWindowCompositionAttribute)(HWND, void *) = 0;
 static BOOL (WINAPI * pSystemParametersInfo)(UINT, UINT, PVOID, UINT) = 0;
 
-typedef enum PREFERRED_APP_MODE
+typedef enum PREFERRED_APP_MODE /* undocumented */
 {
   PREFERRED_APP_MODE_DEFAULT,
   PREFERRED_APP_MODE_ALLOW_DARK,
   PREFERRED_APP_MODE_FORCE_DARK,
   PREFERRED_APP_MODE_FORCE_LIGHT
-} PREFERRED_APP_MODE; /* undocumented */
+} PREFERRED_APP_MODE;
 
 static BOOLEAN (WINAPI * pShouldAppsUseDarkMode)(void) = 0; /* undocumented */
 static BOOL (WINAPI * pAllowDarkModeForApp)(BOOL) = 0; /* undocumented */

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -193,7 +193,7 @@ static HRESULT (WINAPI * pDwmSetWindowAttribute)(HWND, DWORD, LPCVOID, DWORD) = 
 static HRESULT (WINAPI * pSetWindowCompositionAttribute)(HWND, void *) = 0;
 static BOOL (WINAPI * pSystemParametersInfo)(UINT, UINT, PVOID, UINT) = 0;
 
-typedef enum PREFERRED_APP_MODE /* undocumented */
+typedef enum PREFERRED_APP_MODE /* undocumented, use capital letters to fit api style of winapi */
 {
   PREFERRED_APP_MODE_DEFAULT,
   PREFERRED_APP_MODE_ALLOW_DARK,
@@ -205,7 +205,6 @@ static BOOLEAN (WINAPI * pShouldAppsUseDarkMode)(void) = 0; /* undocumented */
 static BOOL (WINAPI * pAllowDarkModeForApp)(BOOL) = 0; /* undocumented */
 static PREFERRED_APP_MODE (WINAPI * pSetPreferredAppMode)(PREFERRED_APP_MODE) = 0; /* undocumented */
 static void (WINAPI * pFlushMenuThemes)(void) = 0; /* undocumented */
-static BOOLEAN (WINAPI * pShouldSystUseDarkMode)(void) = 0; /* undocumented */
 static HRESULT (WINAPI * pSetWindowTheme)(HWND, const wchar_t *, const wchar_t *) = 0;
 
 #define HTHEME HANDLE
@@ -277,8 +276,6 @@ load_dwm_funcs(void)
     }
     pFlushMenuThemes = 
       (void *)GetProcAddress(uxtheme, MAKEINTRESOURCEA(136)); /* ordinal */
-    pShouldSystUseDarkMode = 
-      (void *)GetProcAddress(uxtheme, MAKEINTRESOURCEA(138)); /* ordinal */
     pSetWindowTheme = 
       (void *)GetProcAddress(uxtheme, "SetWindowTheme");
     pOpenThemeData =
@@ -4978,14 +4975,13 @@ main(int argc, char *argv[])
       pSetPreferredAppMode(PREFERRED_APP_MODE_ALLOW_DARK);
     }
   }
-  if (pShouldSystUseDarkMode || pShouldAppsUseDarkMode) {
+  if (pShouldAppsUseDarkMode) {
     HIGHCONTRASTW hc;
     hc.cbSize = sizeof hc;
     pSystemParametersInfo(SPI_GETHIGHCONTRAST, sizeof hc, &hc, 0);
     //printf("High Contrast scheme <%ls>\n", hc.lpszDefaultScheme);
 
-    if (!(hc.dwFlags & HCF_HIGHCONTRASTON) &&
-      (pShouldSystUseDarkMode ? pShouldSystUseDarkMode() : pShouldAppsUseDarkMode())) {
+    if (!(hc.dwFlags & HCF_HIGHCONTRASTON) && pShouldAppsUseDarkMode()) {
       pSetWindowTheme(wnd, W("DarkMode_Explorer"), NULL);
       BOOL dark = 1;
 

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -232,12 +232,9 @@ load_sys_library(string name)
 static DWORD
 get_sys_build(void)
 {
-  if (pRtlGetNtVersionNumbers) {
-    DWORD build;
-    pRtlGetNtVersionNumbers(NULL, NULL, &build);
-    return build & ~0xF0000000;
-  }
-  return 1; /* a small build number */
+  DWORD build;
+  pRtlGetNtVersionNumbers(NULL, NULL, &build);
+  return build & ~0xF0000000;
 }
 
 static void
@@ -4997,6 +4994,8 @@ main(int argc, char *argv[])
       if (hr) { /* failed */
         pDwmSetWindowAttribute(wnd, 19, &dark, sizeof dark);
       }
+
+      pFlushMenuThemes();
     }
   }
 

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -202,7 +202,7 @@ typedef enum PREFERRED_APP_MODE /* undocumented, use capital letters to fit api 
 } PREFERRED_APP_MODE;
 
 static BOOLEAN (WINAPI * pShouldAppsUseDarkMode)(void) = 0; /* undocumented */
-static BOOL (WINAPI * pAllowDarkModeForApp)(BOOL) = 0; /* undocumented */
+static BOOLEAN (WINAPI * pAllowDarkModeForApp)(BOOLEAN) = 0; /* undocumented */
 static PREFERRED_APP_MODE (WINAPI * pSetPreferredAppMode)(PREFERRED_APP_MODE) = 0; /* undocumented */
 static void (WINAPI * pFlushMenuThemes)(void) = 0; /* undocumented */
 static HRESULT (WINAPI * pSetWindowTheme)(HWND, const wchar_t *, const wchar_t *) = 0;


### PR DESCRIPTION
Fixes #983 

* Use undocumented api `RtlGetNtVersionNumbers` to get build number.
* Determine if it is 1903+, and use different apis.

Before (current one shipped with msys2):
![Before](https://user-images.githubusercontent.com/37586447/78972243-db435300-7b3f-11ea-9118-4ecb8f267b1f.png)

After:
![After](https://user-images.githubusercontent.com/37586447/78972268-ef875000-7b3f-11ea-8edd-d93b8cb9d980.png)
