### PR TITLE
simplify scrollback compression and improve performance.

### DIFF
--- a/src/term.h
+++ b/src/term.h
@@ -205,6 +205,7 @@ enum {
 
 typedef unsigned long long cattrflags;
 
+// NOTE: cattr_eq() should be updated if new fields are added.
 typedef struct {
   cattrflags attr;
   colour truebg;


### PR DESCRIPTION
This PR optimizes the scrollback compression code, the aim is faster scrolling speed, lower CPU usage, and simpler code.

I've done some profiling and here is a CPU frame graph:
![PerfViewData orig flameGraph1](https://user-images.githubusercontent.com/9835862/80858757-f7916600-8c8d-11ea-80e3-679e817be6ab.png)

A large portion of CPU time is spent on compressing the scrollback (`compressline`) when a new line is added.
The `compressline` uses RLE encoding for each field of `termchar`. Unfortunately, the RLE implementation is slow and has a large room for improvement.
The current RLE implementation is doing `memcmp` on encoded elements, which is slow because every element will be encoded once, this can be improved by doing comparison *before* the encoding, thus avoids unnecessary encoding.
The functions for encoding each element (`makeliteral_attr` etc) also causes slowness, because those functions are called in hot loops and are not inlined.

This PR introduces the following changes:
- For the encoding of `cattr` fields, RLE encoding is used. Besides the RLE optimization mentioned above, the encoding is in the form of "element + counter", which is simple to code than the original encoding.
- For `chr` fields, RLE encoding is overkill and not used, because the only compressible thing is the repetitive white spaces. non-space characters are encoded as-is, while white space character is followed by a counter.
- For `cc_next` fields, the encoding is similar to `chr`, only repetitive zeros are compressed.
- The whole array of `line->chars` is encoding in each pass, this saves the trouble of handling the linked list and simplifies code.

Here is the optimized framegraph:
![PerfViewData 3 flameGraph2](https://user-images.githubusercontent.com/9835862/80859358-c6fffb00-8c92-11ea-8c17-57e360343940.png)
The width of `compressline` (the second peak in graph) is reduced.

I've measured the memory usage of the optimized encoding, the result is on par with the previous encoding.

The compression code can be further simplified by replacing `makeliteral_attr`/`writevint` with a plain `memcpy`, at the expense of a small increase of memory usage. This is not included in this PR.
