### PR TITLE
maximize child windows if the parent window is maximized.

### DIFF
--- a/src/child.c
+++ b/src/child.c
@@ -1143,6 +1143,14 @@ do_child_fork(int argc, char *argv[], int moni, bool launch)
     // propagate shortcut-inherited icon
     if (icon_is_from_shortcut)
       setenv("MINTTY_ICON", cs__wcstoutf(cfg.icon), true);
+    // provide environment to to maximize window
+    {
+      WINDOWPLACEMENT wndpl = {.length = sizeof wndpl};
+      (void) GetWindowPlacement(wnd, &wndpl);
+      if (wndpl.showCmd == SW_SHOWMAXIMIZED) {
+        setenvi("MINTTY_MAXIMIZE", 1);
+      }
+    }
 
     //setenv("MINTTY_CHILD", "1", true);
 

--- a/src/child.c
+++ b/src/child.c
@@ -1144,12 +1144,8 @@ do_child_fork(int argc, char *argv[], int moni, bool launch)
     if (icon_is_from_shortcut)
       setenv("MINTTY_ICON", cs__wcstoutf(cfg.icon), true);
     // provide environment to to maximize window
-    {
-      WINDOWPLACEMENT wndpl = {.length = sizeof wndpl};
-      (void) GetWindowPlacement(wnd, &wndpl);
-      if (wndpl.showCmd == SW_SHOWMAXIMIZED) {
-        setenvi("MINTTY_MAXIMIZE", 1);
-      }
+    if (IsZoomed(wnd)) {
+      setenvi("MINTTY_MAXIMIZE", 1);
     }
 
     //setenv("MINTTY_CHILD", "1", true);

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -4599,6 +4599,11 @@ main(int argc, char *argv[])
     monitor = atoi(getenv("MINTTY_MONITOR"));
     unsetenv("MINTTY_MONITOR");
   }
+  bool maximize = false;
+  if (getenv("MINTTY_MAXIMIZE")) {
+    maximize = !!atoi(getenv("MINTTY_MAXIMIZE"));
+    unsetenv("MINTTY_MAXIMIZE");
+  }
 
   // if started from console, try to detach from caller's terminal (~daemonizing)
   // in order to not suppress signals
@@ -5216,7 +5221,7 @@ main(int argc, char *argv[])
   // Determine how to show the window.
   go_fullscr_on_max = (cfg.window == -1);
   default_size_token = true;  // prevent font zooming (#708)
-  int show_cmd = go_fullscr_on_max ? SW_SHOWMAXIMIZED : cfg.window;
+  int show_cmd = (go_fullscr_on_max || maximize) ? SW_SHOWMAXIMIZED : cfg.window;
   show_cmd = win_fix_taskbar_max(show_cmd);
 
   // Scale to background image aspect ratio if requested


### PR DESCRIPTION
The window opened with `alt+f2` preserves window size, but not the window placement.
Pressing `alt+f2` on a maximized window opens a window with the size of a maximized window, but the opened window is not maximized, which looks strange.
