### PR TITLE
tabbar: Fix startup position

### DIFF
--- a/src/child.h
+++ b/src/child.h
@@ -26,6 +26,7 @@ extern void user_command(wstring commands, int n);
 extern wstring child_conv_path(wstring, bool adjust_dir);
 extern void child_fork(int argc, char * argv[], int moni, bool config_size);
 extern void child_set_fork_dir(char *);
+extern void setenvi(char * env, int val);
 extern void child_launch(int n, int argc, char * argv[], int moni);
 
 #endif

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -5468,6 +5468,24 @@ main(int argc, char *argv[])
     trace_winsize("border_style");
   }
 
+  if (cfg.tabbar && !getenv("MINTTY_DX") && !getenv("MINTTY_DY")) {
+    HWND wnd_other = FindWindowEx(NULL, wnd,
+        (LPCTSTR)(uintptr_t)class_atom, NULL);
+    if (wnd_other) {
+      if (IsZoomed(wnd_other)) {
+        setenvi("MINTTY_DX", 0);
+        setenvi("MINTTY_DY", 0);
+      } else {
+        RECT r;
+        GetWindowRect(wnd_other, &r);
+        setenvi("MINTTY_X", r.left);
+        setenvi("MINTTY_Y", r.top);
+        setenvi("MINTTY_DX", r.right - r.left);
+        setenvi("MINTTY_DY", r.bottom - r.top);
+      }
+    }
+  }
+
   {
     // INT16 to handle multi-monitor negative coordinates properly
     INT16 sx = 0, sy = 0, sdx = 1, sdy = 1;


### PR DESCRIPTION
When tabbar is enabled, users may expect that all mintty windows are
placed at the same position.
If Alt+F2 is used, the new window is placed at the same position as the
current window. However, if mintty is executed in another way, the
position is not the same as the current window.

This fixes the position of a new window even if Alt+F2 is not used.