### PR TITLE
tabbar: Fix startup position of maximised window

### DIFF
--- a/src/child.c
+++ b/src/child.c
@@ -1015,7 +1015,7 @@ setup_sync()
       setenvi("MINTTY_DX", 0);
       setenvi("MINTTY_DY", 0);
     }
-    else {
+    else if (!IsZoomed(wnd)) {
       RECT r;
       GetWindowRect(wnd, &r);
       setenvi("MINTTY_X", r.left);

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -5473,9 +5473,15 @@ main(int argc, char *argv[])
         (LPCTSTR)(uintptr_t)class_atom, NULL);
     if (wnd_other) {
       if (IsZoomed(wnd_other)) {
-        setenvi("MINTTY_DX", 0);
-        setenvi("MINTTY_DY", 0);
-      } else {
+        if ((GetWindowLong(wnd_other, GWL_STYLE) & WS_THICKFRAME) == 0) {
+          setenvi("MINTTY_DX", 0);
+          setenvi("MINTTY_DY", 0);
+        }
+        else {
+          run_max = 1;
+        }
+      }
+      else {
         RECT r;
         GetWindowRect(wnd_other, &r);
         setenvi("MINTTY_X", r.left);


### PR DESCRIPTION
This fixes two issues:

1. Distinguish a maximised window from a fullscreen window.
   This is an additional fix to #1044.
2. Fix Alt+Shift+F2 behavior on a maximised window.
   When Alt+Shift+F2 was pressed on a maximised window, the new window didn't become a maximised window.