### PR TITLE
Fix window positioning

### DIFF
--- a/src/child.c
+++ b/src/child.c
@@ -1140,8 +1140,8 @@ do_child_fork(int argc, char *argv[], int moni, bool launch, bool config_size)
 
     // provide environment to clone size
     if (!config_size) {
-      setenvi("MINTTY_ROWS", term.rows);
-      setenvi("MINTTY_COLS", term.cols);
+      setenvi("MINTTY_ROWS", term.rows0);
+      setenvi("MINTTY_COLS", term.cols0);
       // provide environment to maximise window
       if (win_is_fullscreen)
         setenvi("MINTTY_MAXIMIZE", 2);

--- a/src/termout.c
+++ b/src/termout.c
@@ -2493,7 +2493,7 @@ do_winop(void)
       // Ps = 9 ; 1  -> Maximize window (i.e., resize to screen size).
       // Ps = 9 ; 2  -> Maximize window vertically.
       // Ps = 9 ; 3  -> Maximize window horizontally.
-      int rows0 = term.rows, cols0 = term.cols;
+      int rows0 = term.rows0, cols0 = term.cols0;
       if (arg1 == 2) {
         // maximize window vertically
         win_set_geom(0, -1, 0, -1);
@@ -2506,10 +2506,11 @@ do_winop(void)
       }
       else if (arg1 == 1) {
         win_maximise(1);
+        term.rows0 = rows0; term.cols0 = cols0;
       }
       else if (arg1 == 0) {
         win_maximise(0);
-        win_set_chars(term.rows0, term.cols0);
+        win_set_chars(rows0, cols0);
       }
     }
     when 10:

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -5479,8 +5479,8 @@ main(int argc, char *argv[])
   }
 
   if (cfg.tabbar && !getenv("MINTTY_DX") && !getenv("MINTTY_DY")) {
-    HWND wnd_other = FindWindowEx(NULL, wnd,
-        (LPCTSTR)(uintptr_t)class_atom, NULL);
+    HWND wnd_other = FindWindowExW(NULL, wnd,
+        (LPCWSTR)(uintptr_t)class_atom, NULL);
     if (wnd_other && FindWindowExA(wnd_other, NULL, TABBARCLASS, NULL)) {
       if (IsZoomed(wnd_other)) {
         if ((GetWindowLong(wnd_other, GWL_STYLE) & WS_THICKFRAME) == 0) {

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -3273,7 +3273,12 @@ static struct {
                        && !ctrl
                        ;
         //printf("WM_SIZE scale_font %d zoom_token %d\n", scale_font, zoom_token);
+        int rows0 = term.rows0, cols0 = term.cols0;
         win_adapt_term_size(false, scale_font);
+        if (wp == SIZE_MAXIMIZED) {
+          term.rows0 = rows0;
+          term.cols0 = cols0;
+        }
         if (zoom_token > 0)
           zoom_token = zoom_token >> 1;
         default_size_token = false;
@@ -5606,6 +5611,10 @@ main(int argc, char *argv[])
   // Cloning fullscreen window
   if (run_max == 2)
     win_maximise(2);
+
+  // Save the non-maximised window size
+  term.rows0 = term_rows;
+  term.cols0 = term_cols;
 
   // Set up clipboard notifications.
   HRESULT (WINAPI * pAddClipboardFormatListener)(HWND) =

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -5481,7 +5481,7 @@ main(int argc, char *argv[])
   if (cfg.tabbar && !getenv("MINTTY_DX") && !getenv("MINTTY_DY")) {
     HWND wnd_other = FindWindowEx(NULL, wnd,
         (LPCTSTR)(uintptr_t)class_atom, NULL);
-    if (wnd_other) {
+    if (wnd_other && FindWindowExA(wnd_other, NULL, TABBARCLASS, NULL)) {
       if (IsZoomed(wnd_other)) {
         if ((GetWindowLong(wnd_other, GWL_STYLE) & WS_THICKFRAME) == 0) {
           setenvi("MINTTY_DX", 0);

--- a/src/wintab.c
+++ b/src/wintab.c
@@ -18,7 +18,6 @@ static const int max_tab_width = 300;
 static const int min_tab_width = 20;
 static int prev_tab_width = 0;
 
-#define TABBARCLASS "Tabbar"
 #define TABFONTSCALE 9/10
 
 static int

--- a/src/wintab.c
+++ b/src/wintab.c
@@ -276,6 +276,14 @@ tabbar_destroy()
   initialized = false;
 }
 
+static int
+win_get_tabbar_height()
+{
+  int margin = cell_width / 6 + 1;
+  int padding = margin * 2;
+  return cell_height + margin * 2 + padding * 2;
+}
+
 static void
 win_toggle_tabbar(bool show)
 {
@@ -283,9 +291,7 @@ win_toggle_tabbar(bool show)
   GetClientRect(wnd, &cr);
   int width = cr.right - cr.left;
 
-  int margin = cell_width / 6 + 1;
-  int padding = margin * 2;
-  int height = cell_height + margin * 2 + padding * 2;
+  int height = win_get_tabbar_height();
   if (height != TABBAR_HEIGHT && initialized) {
     tabbar_destroy();
   }
@@ -294,7 +300,6 @@ win_toggle_tabbar(bool show)
   }
   tabbar_update();
   if (show) {
-    show = show;
     TABBAR_HEIGHT = height;
     //printf("nweheight");
     SetWindowPos(bar_wnd, 0,
@@ -325,6 +330,13 @@ win_update_tabbar()
   if (win_tabbar_visible()) {
     win_toggle_tabbar(true);
   }
+}
+
+void
+win_prepare_tabbar()
+{
+  if (cfg.tabbar)
+    OFFSET = win_get_tabbar_height();
 }
 
 void

--- a/src/wintab.h
+++ b/src/wintab.h
@@ -1,4 +1,5 @@
 extern bool win_tabbar_visible();
+extern void win_prepare_tabbar();
 extern void win_open_tabbar();
 extern void win_update_tabbar();
 extern void win_close_tabbar();

--- a/src/wintab.h
+++ b/src/wintab.h
@@ -1,3 +1,5 @@
+#define TABBARCLASS "Tabbar"
+
 extern bool win_tabbar_visible();
 extern void win_prepare_tabbar();
 extern void win_open_tabbar();


### PR DESCRIPTION
This fixes two issues about window positioning.

1. Fix Alt+F2 behaviour when the window is maximised.
   See: https://github.com/mintty/mintty/pull/1045#issuecomment-709704486

   This also changes the behaviour of `CSI 9 ; [0-3] t`.
   1. Maximise the window vertically.
      `echo -e '\e[9;2t'`
   2. Maximise the window.
      `echo -e '\e[9;1t'`
   3. Restore the window.
      `echo -e '\e[9;0t'`

   This didn't restore the original window size before maximised vertically.
   But now the original size is restored.
   (I'm not sure about the behaviour in other terminals, though.)

2. Consider the size of tabbar on startup.
   Close #1046.