### PR TITLE
mintheme: Enable saving on WSL without cygwin

### DIFF
--- a/tools/mintheme
+++ b/tools/mintheme
@@ -249,7 +249,12 @@ query() {
 }
 
 conftheme() {
-	themefile=`cygpath -wa "$1"`
+	if [ `uname` = "Linux" ] && [ -n "$APPDATA" ]
+	then
+		themefile=`wslpath -ma "$1"`
+	else
+		themefile=`cygpath -wa "$1"`
+	fi
 	for conffile in ~/.minttyrc ~/.config/mintty/config "$APPDATA/mintty/config" /etc/minttyrc
 	do	if [ -w "$conffile" ]
 		then


### PR DESCRIPTION
Attempted to follow a similar convention to [existing WSL checks](https://github.com/mintty/mintty/blob/master/tools/mintheme#L280-L286). Let me know if `case` is preferred!

Note: Using `-m` here as opposed to `-w`; When using normal `-w` the back slash would act as an escape for `\theme` and 

```
C:\Users\blah\AppData\Romaing\mintty\themes
```
would turn into
```
C:\Users\blah\AppData\Romaing\mintty     hemes
```

I've verified that mintty is capable of handing `C:/Users/blah/AppData/Romaing/mintty/themes`, but if you'd prefer something more akin to ${themefile//\\/\\\\} just let me know!