### PR TITLE
Separate foreground and background values for ANSI colours

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-mintty is copyright 2008-13 Andy Koppe, 2015-22 Thomas Wolff.
+mintty is copyright 2008-22 Andy Koppe, 2015-22 Thomas Wolff.
 
 Licensed under the terms of the GNU General Public License version 3 or later,
 amended with the bundling clause to clarify ambiguous interpretation.

--- a/docs/mintty.1
+++ b/docs/mintty.1
@@ -39,7 +39,7 @@ Mintty supports being started from a Windows desktop shortcut; it honours
 window and icon settings of the shortcut, aligns taskbar grouping with the 
 shortcut, disables daemonizing, and sets environment variable 
 MINTTY_SHORTCUT to its pathname.
-.br
+
 Before starting the child program, mintty trims the environment from other 
 variables set by launchers, other terminals, or shells, that might indicate 
 incorrect information and lead to confusing behaviour.
@@ -48,7 +48,7 @@ incorrect information and lead to confusing behaviour.
 
 The standard GNU option formats are accepted, with single dashes
 introducing short options and double dashes introducing long options.
-.br
+
 Note that setting \fBShortLongOpts\fP enables single-dash long options.
 
 .TQ
@@ -3183,45 +3183,52 @@ By default, this is unset, which means that the cursor colour does not change.
 
 .TQ
 \fBANSI colours\fP
-These are the 16 ANSI colour settings along with their default values.
-Colours are represented as comma-separated RGB triples with decimal 8-bit values
-ranging from 0 to 255. 
-X-style hexadecimal colour specifications such as #RRGGBB, 
-rgb:RR/GG/BB or rgb:RRRR/GGGG/BBBB, 
-cmy:C.C/M.M/Y.Y or cmyk:C.C/M.M/Y.Y/K.K can be used as well.
-Also X11 color names are supported.
+The sixteen ANSI colours can be chosen with the settings below. Colours are
+represented as comma-separated RGB triples with decimal 8-bit values ranging
+from 0 to 255.
+
+X11-style hexadecimal colour specifications such as #RRGGBB, rgb:RR/GG/BB, rgb:RRRR/GGGG/BBBB, cmy:C.C/M.M/Y.Y or cmyk:C.C/M.M/Y.Y/K.K, as well as X11
+colour names, can be used as well.
+
+The ANSI colours can have different values for foreground and background use.
+These need to be separated by a semicolon, for example 127,127,127;85,85,85
+for different shades of grey. If only one value is specified, it is used for
+both foreground and background.
+
+For the default values, please see the 'helmholtz' theme in directory
+/usr/share/mintty/themes.
+
+\(en \fBBlack\fP=
 .br
-\(en \fBBlack\fP=0,0,0
+\(en \fBRed\fP=
 .br
-\(en \fBRed\fP=191,0,0
+\(en \fBGreen\fP=
 .br
-\(en \fBGreen\fP=0,191,0
+\(en \fBYellow\fP=
 .br
-\(en \fBYellow\fP=191,191,0
+\(en \fBBlue\fP=
 .br
-\(en \fBBlue\fP=0,0,191
+\(en \fBMagenta\fP=
 .br
-\(en \fBMagenta\fP=191,0,191
+\(en \fBCyan\fP=
 .br
-\(en \fBCyan\fP=0,191,191
+\(en \fBWhite\fP=
 .br
-\(en \fBWhite\fP=191,191,191
+\(en \fBBoldBlack\fP=
 .br
-\(en \fBBoldBlack\fP=64,64,64
+\(en \fBBoldRed\fP=
 .br
-\(en \fBBoldRed\fP=255,64,64
+\(en \fBBoldGreen\fP=
 .br
-\(en \fBBoldGreen\fP=64,255,64
+\(en \fBBoldYellow\fP=
 .br
-\(en \fBBoldYellow\fP=255,255,64
+\(en \fBBoldBlue\fP=
 .br
-\(en \fBBoldBlue\fP=96,96,255
+\(en \fBBoldMagenta\fP=
 .br
-\(en \fBBoldMagenta\fP=255,64,255
+\(en \fBBoldCyan\fP=
 .br
-\(en \fBBoldCyan\fP=64,255,255
-.br
-\(en \fBBoldWhite\fP=255,255,255
+\(en \fBBoldWhite\fP=
 
 .TQ
 \fBTektronix mode colours\fP
@@ -3809,7 +3816,7 @@ Additional information can be found on the wiki on the mintty project page
 
 .SH LICENSE
 
-Copyright (C) 2013 Andy Koppe (C) 2022 Thomas Wolff
+Copyright (C) 2022 Thomas Wolff, Andy Koppe
 
 Mintty is released under the terms of the the \fIGNU General Public License\fP
 version 3.

--- a/docs/readme-msys.html
+++ b/docs/readme-msys.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 <p>
-mintty is copyright 2008-13 Andy Koppe, 2015 Thomas Wolff
+Copyright (C) 2022 Thomas Wolff, Andy Koppe
 </p>
 <p>
 This program is distributed in the hope that it will be useful, but without any warranty; 

--- a/docs/readme.html
+++ b/docs/readme.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 <p>
-mintty is copyright 2008-13 Andy Koppe, 2015 Thomas Wolff
+Copyright (C) 2022 Thomas Wolff, Andy Koppe
 </p>
 <p>
 This program is distributed in the hope that it will be useful, but without any warranty; 

--- a/src/appinfo.h
+++ b/src/appinfo.h
@@ -11,9 +11,8 @@
 
 // needed for res.rc
 #define APPDESC "Terminal"
-#define AUTHOR  "Thomas Wolff / Andy Koppe"
-#define YEAR    "2022 / 2013"
-
+#define AUTHOR  "Thomas Wolff, Andy Koppe"
+#define YEAR    "2022"
 
 #define CONCAT_(a,b) a##b
 #define CONCAT(a,b) CONCAT_(a,b)

--- a/src/config.c
+++ b/src/config.c
@@ -1,12 +1,12 @@
 // config.c (part of mintty)
-// Copyright 2008-13 Andy Koppe, 2015-2021 Thomas Wolff
+// Copyright 2008-22 Andy Koppe, 2015-2022 Thomas Wolff
 // Based on code from PuTTY-0.60 by Simon Tatham and team.
 // Licensed under the terms of the GNU General Public License v3 or later.
 
 // Internationalization approach:
 // instead of refactoring a lot of framework functions (here, *ctrls.c)
 // to use Unicode strings, the API is simply redefined to use UTF-8;
-// non-ASCII strings are converted before being passed to the platform 
+// non-ASCII strings are converted before being passed to the platform
 // (using UTF-16 on Windows)
 
 #include "term.h"
@@ -268,22 +268,22 @@ const config default_cfg = {
     [BOLD_CYAN_I]    = RGB(0x40, 0xFF, 0xFF),
     [BOLD_WHITE_I]   = RGB(0xFF, 0xFF, 0xFF)
 #else  // theme "helmholtz"
-    [BLACK_I]        = RGB(  0,   0,   0),
-    [RED_I]          = RGB(216,  36,  51),
-    [GREEN_I]        = RGB( 28, 168,   0),
-    [YELLOW_I]       = RGB(192, 160,   0),
-    [BLUE_I]         = RGB(  0,  55, 220),
-    [MAGENTA_I]      = RGB(177,  72, 198),
-    [CYAN_I]         = RGB(  0, 168, 154),
-    [WHITE_I]        = RGB(191, 191, 191),
-    [BOLD_BLACK_I]   = RGB( 96,  96,  96),
-    [BOLD_RED_I]     = RGB(255, 102, 102),
-    [BOLD_GREEN_I]   = RGB(  0, 244,   0),
-    [BOLD_YELLOW_I]  = RGB(240, 240,   0),
-    [BOLD_BLUE_I]    = RGB( 85, 170, 255),
-    [BOLD_MAGENTA_I] = RGB(255, 114, 255),
-    [BOLD_CYAN_I]    = RGB(  0, 240, 240),
-    [BOLD_WHITE_I]   = RGB(255, 255, 255)
+    [BLACK_I]        = { RGB(  0,   0,   0), RGB(  0,   0,   0) },
+    [RED_I]          = { RGB(212,  44,  58), RGB(167,  35,  46) },
+    [GREEN_I]        = { RGB( 28, 168,   0), RGB( 22, 132,   0) },
+    [YELLOW_I]       = { RGB(192, 160,   0), RGB(192, 160,   0) },
+    [BLUE_I]         = { RGB( 30, 123, 216), RGB(  0,  45, 180) },
+    [MAGENTA_I]      = { RGB(177,  72, 198), RGB(138,  58, 154) },
+    [CYAN_I]         = { RGB(  0, 168, 154), RGB(  0, 132, 121) },
+    [WHITE_I]        = { RGB(191, 191, 191), RGB(191, 191, 191) },
+    [BOLD_BLACK_I]   = { RGB(127, 127, 127), RGB( 85,  85,  85) },
+    [BOLD_RED_I]     = { RGB(255, 118, 118), RGB(255, 118, 118) },
+    [BOLD_GREEN_I]   = { RGB(  0, 242,   0), RGB(  0, 242,   0) },
+    [BOLD_YELLOW_I]  = { RGB(242, 242,   0), RGB(242, 242,   0) },
+    [BOLD_BLUE_I]    = { RGB(125, 177, 255), RGB(125, 177, 255) },
+    [BOLD_MAGENTA_I] = { RGB(255, 112, 255), RGB(255, 112, 255) },
+    [BOLD_CYAN_I]    = { RGB(  0, 240, 240), RGB(  0, 240, 240) },
+    [BOLD_WHITE_I]   = { RGB(255, 255, 255), RGB(255, 255, 255) }
 #endif
   },
   .sixel_clip_char = W(" "),
@@ -300,7 +300,7 @@ config cfg, new_cfg, file_cfg;
 typedef enum {
   OPT_BOOL, OPT_MOD, OPT_TRANS, OPT_CURSOR, OPT_FONTSMOOTH, OPT_FONTRENDER,
   OPT_MIDDLECLICK, OPT_RIGHTCLICK, OPT_SCROLLBAR, OPT_WINDOW, OPT_HOLD,
-  OPT_INT, OPT_COLOUR, OPT_STRING, OPT_WSTRING,
+  OPT_INT, OPT_COLOUR, OPT_COLOUR_PAIR, OPT_STRING, OPT_WSTRING,
   OPT_CHARWIDTH, OPT_EMOJIS, OPT_EMOJI_PLACEMENT,
   OPT_COMPOSE_KEY,
   OPT_TYPE_MASK = 0x1F,
@@ -583,22 +583,22 @@ options[] = {
   {"OldOptions", OPT_STRING, offcfg(old_options)},
 
   // ANSI colours
-  {"Black", OPT_COLOUR, offcfg(ansi_colours[BLACK_I])},
-  {"Red", OPT_COLOUR, offcfg(ansi_colours[RED_I])},
-  {"Green", OPT_COLOUR, offcfg(ansi_colours[GREEN_I])},
-  {"Yellow", OPT_COLOUR, offcfg(ansi_colours[YELLOW_I])},
-  {"Blue", OPT_COLOUR, offcfg(ansi_colours[BLUE_I])},
-  {"Magenta", OPT_COLOUR, offcfg(ansi_colours[MAGENTA_I])},
-  {"Cyan", OPT_COLOUR, offcfg(ansi_colours[CYAN_I])},
-  {"White", OPT_COLOUR, offcfg(ansi_colours[WHITE_I])},
-  {"BoldBlack", OPT_COLOUR, offcfg(ansi_colours[BOLD_BLACK_I])},
-  {"BoldRed", OPT_COLOUR, offcfg(ansi_colours[BOLD_RED_I])},
-  {"BoldGreen", OPT_COLOUR, offcfg(ansi_colours[BOLD_GREEN_I])},
-  {"BoldYellow", OPT_COLOUR, offcfg(ansi_colours[BOLD_YELLOW_I])},
-  {"BoldBlue", OPT_COLOUR, offcfg(ansi_colours[BOLD_BLUE_I])},
-  {"BoldMagenta", OPT_COLOUR, offcfg(ansi_colours[BOLD_MAGENTA_I])},
-  {"BoldCyan", OPT_COLOUR, offcfg(ansi_colours[BOLD_CYAN_I])},
-  {"BoldWhite", OPT_COLOUR, offcfg(ansi_colours[BOLD_WHITE_I])},
+  {"Black", OPT_COLOUR_PAIR, offcfg(ansi_colours[BLACK_I])},
+  {"Red", OPT_COLOUR_PAIR, offcfg(ansi_colours[RED_I])},
+  {"Green", OPT_COLOUR_PAIR, offcfg(ansi_colours[GREEN_I])},
+  {"Yellow", OPT_COLOUR_PAIR, offcfg(ansi_colours[YELLOW_I])},
+  {"Blue", OPT_COLOUR_PAIR, offcfg(ansi_colours[BLUE_I])},
+  {"Magenta", OPT_COLOUR_PAIR, offcfg(ansi_colours[MAGENTA_I])},
+  {"Cyan", OPT_COLOUR_PAIR, offcfg(ansi_colours[CYAN_I])},
+  {"White", OPT_COLOUR_PAIR, offcfg(ansi_colours[WHITE_I])},
+  {"BoldBlack", OPT_COLOUR_PAIR, offcfg(ansi_colours[BOLD_BLACK_I])},
+  {"BoldRed", OPT_COLOUR_PAIR, offcfg(ansi_colours[BOLD_RED_I])},
+  {"BoldGreen", OPT_COLOUR_PAIR, offcfg(ansi_colours[BOLD_GREEN_I])},
+  {"BoldYellow", OPT_COLOUR_PAIR, offcfg(ansi_colours[BOLD_YELLOW_I])},
+  {"BoldBlue", OPT_COLOUR_PAIR, offcfg(ansi_colours[BOLD_BLUE_I])},
+  {"BoldMagenta", OPT_COLOUR_PAIR, offcfg(ansi_colours[BOLD_MAGENTA_I])},
+  {"BoldCyan", OPT_COLOUR_PAIR, offcfg(ansi_colours[BOLD_CYAN_I])},
+  {"BoldWhite", OPT_COLOUR_PAIR, offcfg(ansi_colours[BOLD_WHITE_I])},
 
   // Legacy
   {"BoldAsBright", OPT_BOOL | OPT_LEGACY, offcfg(bold_as_colour)},
@@ -1006,6 +1006,21 @@ set_option(string name, string val_str, bool from_file)
 #endif
       if (parse_colour(val_str, val_p))
         return i;
+    when OPT_COLOUR_PAIR: {
+#ifdef debug_theme
+      printf("set_option <%s> <%s>\n", name, val_str);
+#endif
+      colour_pair *pair = val_p;
+      if (parse_colour(val_str, &pair->fg)) {
+        const char *sep = strchr(val_str, ';');
+        if (!sep) {
+          pair->bg = pair->fg;
+          return i;
+        }
+        else if (parse_colour(sep + 1, &pair->bg))
+          return i;
+      }
+    }
     otherwise: {
       int len = strlen(val_str);
       if (!len)
@@ -1622,8 +1637,12 @@ copy_config(char * tag, config * dst_p, const config * src_p)
           strset(dst_val_p, *(string *)src_val_p);
         when OPT_WSTRING:
           wstrset(dst_val_p, *(wstring *)src_val_p);
-        when OPT_INT or OPT_COLOUR:
+        when OPT_INT:
           *(int *)dst_val_p = *(int *)src_val_p;
+        when OPT_COLOUR:
+          *(colour *)dst_val_p = *(colour *)src_val_p;
+        when OPT_COLOUR_PAIR:
+          *(colour_pair *)dst_val_p = *(colour_pair *)src_val_p;
         otherwise:
           *(char *)dst_val_p = *(char *)src_val_p;
       }
@@ -1659,7 +1678,7 @@ finish_config(void)
     (void)load_messages_lang("messages");
 #endif
 #ifdef debug_opterror
-  opterror("Täst L %s %s", false, "b�h", "b�h�");
+  opterror("Täst L %s %s", false, "b�h", "b�h�");
   opterror("Täst U %s %s", true, "böh", "büh€");
 #endif
 
@@ -1740,6 +1759,12 @@ save_config(void)
             colour c = *(colour *)val_p;
             fprintf(file, "%u,%u,%u", red(c), green(c), blue(c));
           }
+          when OPT_COLOUR_PAIR: {
+            colour_pair p = *(colour_pair *)val_p;
+            fprintf(file, "%u,%u,%u", red(p.fg), green(p.fg), blue(p.fg));
+            if (p.fg != p.bg)
+              fprintf(file, ";%u,%u,%u", red(p.bg), green(p.bg), blue(p.bg));
+          }
           otherwise: {
             int val = *(char *)val_p;
             opt_val *o = opt_vals[type];
@@ -1784,8 +1809,12 @@ apply_config(bool save)
           changed = strcmp(*(string *)val_p, *(string *)new_val_p);
         when OPT_WSTRING:
           changed = wcscmp(*(wstring *)val_p, *(wstring *)new_val_p);
-        when OPT_INT or OPT_COLOUR:
+        when OPT_INT:
           changed = (*(int *)val_p != *(int *)new_val_p);
+        when OPT_COLOUR:
+          changed = (*(colour *)val_p != *(colour *)new_val_p);
+        when OPT_COLOUR_PAIR:
+          changed = memcmp(val_p, new_val_p, sizeof(colour_pair));
         otherwise:
           changed = (*(char *)val_p != *(char *)new_val_p);
       }

--- a/src/config.h
+++ b/src/config.h
@@ -23,6 +23,7 @@ enum { EMPL_STRETCH = 0, EMPL_ALIGN = 1, EMPL_MIDDLE = 2, EMPL_FULL = 3 };
 // Colour values.
 
 typedef uint colour;
+typedef struct { colour fg, bg; } colour_pair;
 
 enum { DEFAULT_COLOUR = UINT_MAX };
 
@@ -233,7 +234,7 @@ typedef struct {
   string word_chars;
   string word_chars_excl;
   colour ime_cursor_colour;
-  colour ansi_colours[16];
+  colour_pair ansi_colours[16];
   wstring sixel_clip_char;
   bool short_long_opts;
   bool bold_as_special;

--- a/src/term.h
+++ b/src/term.h
@@ -35,40 +35,45 @@ typedef enum {
   // on grounds of redundancy.
 
   // Colour numbers 256 through 271 are copies of ANSI colours 0 through 15
-  // supporting distinct handling of ANSI colours SGR 30..37/40../90../100.. 
-  // and palette colours SGR 38/48;5;0..15
+  // supporting distinct handling of ANSI colours SGR 30..37/40../90../100..
+  // and palette colours SGR 38/48;5;0..15.
   // For distinct bold handling alone, they could also be mapped to 0..15
-  // but duplicating them would also facilitate distinct colour values if desired
+  // but duplicating them could also facilitate distinct colour values if
+  // desired.
   ANSI0            = 256,
 
+  // Colour numbers 272 through 287 are the background variants of the ANSI
+  // colours.
+  BG_ANSI0         = 272,
+
   // Default foreground
-  FG_COLOUR_I      = 272,
-  BOLD_FG_COLOUR_I = 273,
+  FG_COLOUR_I      = 288,
+  BOLD_FG_COLOUR_I = 289,
 
   // Default background
-  BG_COLOUR_I      = 274,
-  BOLD_BG_COLOUR_I = 275,
+  BG_COLOUR_I      = 290,
+  BOLD_BG_COLOUR_I = 291,
 
   // Cursor colours
-  CURSOR_TEXT_COLOUR_I = 276,
-  CURSOR_COLOUR_I      = 277,
-  IME_CURSOR_COLOUR_I  = 278,
+  CURSOR_TEXT_COLOUR_I = 292,
+  CURSOR_COLOUR_I      = 293,
+  IME_CURSOR_COLOUR_I  = 294,
 
   // Selection highlight colours
-  SEL_COLOUR_I         = 279,
-  SEL_TEXT_COLOUR_I    = 280,
+  SEL_COLOUR_I         = 295,
+  SEL_TEXT_COLOUR_I    = 296,
 
   // configured attribute substitution colours
-  BOLD_COLOUR_I = 281,
-  BLINK_COLOUR_I = 282,
+  BOLD_COLOUR_I = 297,
+  BLINK_COLOUR_I = 298,
 
   // Tektronix colours
-  TEK_FG_COLOUR_I      = 283,
-  TEK_BG_COLOUR_I      = 284,
-  TEK_CURSOR_COLOUR_I  = 285,
+  TEK_FG_COLOUR_I      = 299,
+  TEK_BG_COLOUR_I      = 300,
+  TEK_CURSOR_COLOUR_I  = 301,
 
   // Number of colours
-  COLOUR_NUM = 286,
+  COLOUR_NUM = 302,
 
   // True Colour indicator
   // assert (TRUE_COLOUR % 4) == 0 so that checking x >= TRUE_COLOUR
@@ -78,6 +83,7 @@ typedef enum {
 
 // colour classes
 #define CCL_ANSI8(i) ((i) >= ANSI0 && (i) < ANSI0 + 8)
+#define CCL_BG_ANSI8(i) ((i) >= BG_ANSI0 && (i) < BG_ANSI0 + 8)
 #define CCL_DEFAULT(i) ((i) >= FG_COLOUR_I && (i) <= BOLD_BG_COLOUR_I)
 #define CCL_TRUEC(i) ((i) >= TRUE_COLOUR)
 

--- a/themes/helmholtz
+++ b/themes/helmholtz
@@ -1,10 +1,9 @@
 # "helmholtz" colour theme for mintty
 #
 # The aim of this theme is to provide vibrant colours where the normal and bold
-# levels each have approximately equal brightness. The exception is normal blue,
-# which is somewhat darker than the others as a compromise between readability
-# on a black background and suitability as a background colour. The variants of
-# each colour have slightly different hues to help distinguish them.
+# levels each have approximately equal brightness. Additionally, the normal
+# colours apart from yellow have darker variants for use as background colours,
+# to help legibility of light text on them.
 #
 # To level the colours, their luminance was calculated as follows:
 # - Gamma-expand the sRGB components by dividing each by 255 and applying the
@@ -29,19 +28,19 @@
 # Of course, that is a highly subjective process ...
 
 Black=0,0,0
-Red=216,36,51
-Green=28,168,0
+Red=212,44,58;167,35,46
+Green=28,168,0;22,132,0
 Yellow=192,160,0
-Blue=0,55,220
-Magenta=177,72,198
-Cyan=0,168,154
+Blue=30,123,216;0,45,180
+Magenta=177,72,198;138,58,154
+Cyan=0,168,154;0,132,121
 White=191,191,191
 
-BoldBlack=96,96,96
-BoldRed=255,102,102
-BoldGreen=0,244,0
-BoldYellow=240,240,0
-BoldBlue=85,170,255
-BoldMagenta=255,114,255
+BoldBlack=127,127,127;85,85,85
+BoldRed=255,118,118
+BoldGreen=0,242,0
+BoldYellow=242,242,0
+BoldBlue=125,177,255
+BoldMagenta=255,112,255
 BoldCyan=0,240,240
 BoldWhite=255,255,255

--- a/themes/kohlrausch
+++ b/themes/kohlrausch
@@ -1,12 +1,8 @@
 # "kohlrausch" colour theme for mintty
 #
-# The aim of this theme is to provide vibrant colours where the normal and bold
-# levels each have approximately equal brightness. The variants of each colour
-# have slightly different hues to help distinguish them.
-#
-# Unlike in the "helmholtz" scheme, the normal blue has a similar brightness to
-# the other normal colours, which helps its readability but makes it less
-# suitable as a background colour.
+# This is a variant of the "helmholtz" theme that has been designed for use
+# with a dark text colour and light background, by darkening the foreground
+# variants of the normal colours and brightening the background ones.
 #
 # To level the colours, their luminance was calculated as follows:
 # - Gamma-expand the sRGB components by dividing each by 255 and applying the
@@ -30,20 +26,26 @@
 # for yellow to 1.45 for red, and the colour components adjusted accordingly.
 # Of course, that is a highly subjective process ...
 
+ForegroundColour=0,0,0
+BackgroundColour=255,255,255
+CursorColour=0,0,0
+BoldAsColour=no
+BoldAsFont=yes
+
 Black=0,0,0
-Red=216,36,51
-Green=28,168,0
-Yellow=192,160,0
-Blue=0,102,255
-Magenta=177,72,198
-Cyan=0,168,154
+Red=167,35,46;212,44,58
+Green=22,132,0;28,168,0
+Yellow=150,125,0;192,160,0
+Blue=0,45,180
+Magenta=138,58,154;177,72,198
+Cyan=0,132,121;0,168,154
 White=191,191,191
 
-BoldBlack=96,96,96
-BoldRed=255,102,102
-BoldGreen=0,244,0
-BoldYellow=240,240,0
-BoldBlue=85,170,255
-BoldMagenta=255,114,255
+BoldBlack=64,64,64;127,127,127
+BoldRed=255,118,118
+BoldGreen=0,242,0
+BoldYellow=242,242,0
+BoldBlue=125,177,255
+BoldMagenta=255,112,255
 BoldCyan=0,240,240
 BoldWhite=255,255,255

--- a/wiki/CtrlSeqs.md
+++ b/wiki/CtrlSeqs.md
@@ -737,6 +737,31 @@ a mintty resource directory; supported file types are .cur, .ico, .ani.
 |:----------------------|
 | `^[]22;`_pointer_`^G` |
 
+## ANSI colours ##
+
+The following _OSC_ sequences can be used to set or query the foreground and
+background variants of the ANSI colours.
+
+| **sequence**                        | ** effect **                         |
+|:------------------------------------|:-------------------------------------|
+| `^[]7765;`_index_`;`_colour_`^G`    | set fg and bg variants to same value |
+| `^[]7765;`_index_`;`_fg_`;`_bg_`^G` | set fg and bg to separate values     |
+| `^[]7765;`_index_`;?^G`             | query current values                 |
+
+The _index_ argument has to be in range 0 to 15.
+
+The colour values can be comma-separated decimal triples such as `255,85,0`,
+X11 colour names, or hexadecimal colour specifications such as `#`_RRGGBB_,
+`rgb:`_RR_`/`_GG_`/`_BB_, `rgb:`_RRRR_`/`_GGGG_`/`_BBBB_,
+`cmy:`_C_`.`_C_`/`_M_`.`_M_`/`_Y_`.`_Y_ or
+`cmyk:`_C_`.`_C_`/`_M_`.`_M_`/`_Y_`.`_Y_`/`_K_`.`_K_.
+
+If a colour value is left empty, it is reset to the value in the mintty
+configuration. Invalid values are ignored.
+
+The query sequence replies with the single-value sequence if the current values
+for the foreground and background variants are the same, and with the two-value
+sequence otherwise.
 
 ## Printing and screen dump ##
 


### PR DESCRIPTION
Add the ability to specify separate foreground and background values for
the 16 ANSI colours, so that e.g. blue text can be bright enough to be
readable on a dark background, while background blue can be dark enough
to not interfere with light foreground text, e.g. in Midnight Commander.

The values can be given as semicolon-separated pairs in config files.
When only one value is present, it is used for both the foreground and
background, to ensure backward capability with existing themes.

Also add mintty-specific control sequence OSC 7765 for setting and
querying the foreground and background variants of the ANSI colour
values. This sequence does not touch the first sixteen xterm256 colours
that can be controlled through the OSC 4 and 104 sequences. Conversely,
though, for backward compatibility those xterm sequences continue to
control the ANSI colours as well, setting the foreground and background
variants to the same value.

Put the new feature to use in the default 'helmholtz' theme, darkening
background blue a lot and the other non-bold colours by a bit as well,
to improve readability of light text on them. Except for yellow, because
that isn't suitable as background for light text anyway.

Repurpose the 'kohlrausch' theme as a black-on-white one, with darker
foreground than background colour values.

Reflect changes in documentation and bump copyrights.