### PR TITLE
fix typos

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -4454,7 +4454,7 @@ setup_config_box(controlbox * b)
   )->column = 0;
   ctrl_columns(s, 1, 100);  // reset column stuff so we can rearrange them
   // balance column widths of the following 3 fields 
-  // to accomodate different length of localized labels
+  // to accommodate different length of localized labels
   int strwidth(string s0) {
     int len = 0;
     unsigned char * sp = (unsigned char *)s0;

--- a/src/minibidi.c
+++ b/src/minibidi.c
@@ -7,7 +7,7 @@
  * ------------
  * Description:
  * ------------
- * This is an implemention of Unicode's Bidirectional Algorithm
+ * This is an implementation of Unicode's Bidirectional Algorithm
  * (known as UAX #9).
  *
  *   http://www.unicode.org/reports/tr9/

--- a/src/term.c
+++ b/src/term.c
@@ -2265,7 +2265,7 @@ term_erase(bool selective, bool line_only, bool from_begin, bool to_end)
 
    /* After an erase of lines from the top of the screen, we shouldn't
     * bring the lines back again if the terminal enlarges (since the user or
-    * application has explictly thrown them away). */
+    * application has explicitly thrown them away). */
     if (!term.on_alt_screen)
       term.tempsblines = 0;
   }

--- a/src/termout.c
+++ b/src/termout.c
@@ -2273,7 +2273,7 @@ set_modes(bool state)
           term.bracketed_paste = state;
 
         /* Mintty private modes */
-        when 7700:       /* CJK ambigous width reporting */
+        when 7700:       /* CJK ambiguous width reporting */
           term.report_ambig_width = state;
         when 7711:       /* Scroll marker in current line */
           if (state)
@@ -2463,7 +2463,7 @@ get_mode(bool privatemode, int arg)
         return 2 - term.bracketed_paste;
 
       /* Mintty private modes */
-      when 7700:       /* CJK ambigous width reporting */
+      when 7700:       /* CJK ambiguous width reporting */
         return 2 - term.report_ambig_width;
       when 7711:       /* Scroll marker in current line */
         return 2 - !!(term.lines[term.curs.y]->lattr & LATTR_MARKED);

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -666,7 +666,7 @@ update_tab_titles()
     refresh_tab_titles(true);
     // support tabbar
     win_update_tabbar();
-    // tell the others to update their's
+    // tell the others to update theirs
     EnumWindows(wnd_enum_tabs, 0);
   }
 }
@@ -6653,7 +6653,7 @@ static int dynfonts = 0;
   disable_poschange = false;
 
   // Adapt window position (and maybe size) to special parameters,
-  // we need to reconsider maxwidth/maxheight here to accomodate 
+  // we need to reconsider maxwidth/maxheight here to accommodate 
   // circular dependencies of 
   // positioning, monitor selection, DPI adjustment and window size
   if (center || right || bottom || left || top || maxwidth || maxheight) {

--- a/src/wintext.c
+++ b/src/wintext.c
@@ -201,7 +201,7 @@ brighten(colour c, colour against, bool monotone)
   }
 
   colour bright;
-  uint thrsh = 22222;  // contrast threshhold;
+  uint thrsh = 22222;  // contrast threshold;
                        // if we're closer to either fg or bg,
                        // turn "brightening" into the other direction
 


### PR DESCRIPTION
src/config.c
src/minibidi.c
src/term.c
src/termout.c
src/winmain.c
src/wintext.c

other typos not attended to

for toggling
underlying

```
$ grep -nr fortoggling mintty
mintty/docs/mintty.1.html:2363:<b>Alt+F11</b> fortoggling full screen mode. Disable to have
mintty/docs/mintty.1:1856:fortoggling  full screen mode.  Disable to have \fBAlt+Fn\fP combinations
$ grep -nr underlaying mintty
mintty/docs/mintty.1.html:1965:bold attribute by underlaying special background. Overrides
mintty/docs/mintty.1:1538:This hidden option displays the bold attribute by underlaying special
$
```

environment
incompatibility

```
$ grep -nr environent mintty
mintty/wiki/Changelog.md:2056:  * When the locale is set in the options, all LC`_``*` environent variables rather than just LC\_ALL and LC\_CTYPE are now cleared. (LANG is set according to the selected locale.)
$ grep -nr incompatiblity mintty
mintty/wiki/Tips.md:1423:cygwin 3.1.0 provides the ConPTY support to bridge the terminal interworking incompatiblity problems
$ 
```

<hr>

line referring to terminfo is awkwardly written

so I suggest simply deleting the line

wiki/Changelog.md

```diff
    * Restored "Allow blinking" in Options dialog (#1097).
-   * WSL-specific detection of Term info availabilities (mintty/wsltty#278).
    * Export TERM to WSL (mintty/wsltty#278).
```