### PR TITLE
Alt-modified mousewheel mode and other wheel tweaks

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -1,5 +1,5 @@
 // term.c (part of mintty)
-// Copyright 2008-12 Andy Koppe, 2016-2020 Thomas Wolff
+// Copyright 2008-23 Andy Koppe, 2016-2020 Thomas Wolff
 // Adapted from code from PuTTY-0.60 by Simon Tatham and team.
 // Licensed under the terms of the GNU General Public License v3 or later.
 
@@ -346,6 +346,7 @@ term_reset(bool full)
     term.wheel_reporting_xterm = false;
     term.wheel_reporting = true;
     term.app_wheel = false;
+    term.alt_wheel = false;
     term.echoing = false;
     term.bracketed_paste = false;
     term.wide_indic = false;

--- a/src/term.h
+++ b/src/term.h
@@ -548,7 +548,8 @@ struct term {
   bool bell_popup;   // xterm: popOnBell;    switchable with CSI ? 1043 h/l
   bool wheel_reporting_xterm; // xterm: alternateScroll
   bool wheel_reporting;       // similar, but default true
-  bool app_wheel;             // format for wheel_reporting
+  bool app_wheel;             // dedicated wheel codes instead of cursor codes
+  bool alt_wheel;             // add Alt modifier to wheel cursor codes
   int  modify_other_keys;
   bool newline_mode;
   bool report_focus;

--- a/src/termmouse.c
+++ b/src/termmouse.c
@@ -1001,9 +1001,10 @@ term_mouse_wheel(bool horizontal, int delta, int lines_per_notch, mod_keys mods,
                                  : (up ? "\e[5~" : "\e[6~"));
           }
           else {
-            send_keys(count, alt ? (up ? "\e[1;3A" : "\e[1;3B") :
-                             term.app_cursor_keys ? (up ? "\eOA" : "\eOB")
-                                                  : (up ? "\e[A" : "\e[B"));
+            send_keys(count,
+              alt ^ term.alt_wheel ? (up ? "\e[1;3A" : "\e[1;3B") :
+              term.app_cursor_keys ? (up ? "\eOA" : "\eOB")
+                                   : (up ? "\e[A" : "\e[B"));
           }
         }
       }

--- a/src/termout.c
+++ b/src/termout.c
@@ -1,5 +1,5 @@
 // termout.c (part of mintty)
-// Copyright 2008-22 Andy Koppe, 2017-22 Thomas Wolff
+// Copyright 2008-23 Andy Koppe, 2017-22 Thomas Wolff
 // Adapted from code from PuTTY-0.60 by Simon Tatham and team.
 // Licensed under the terms of the GNU General Public License v3 or later.
 
@@ -2311,6 +2311,8 @@ set_modes(bool state)
           term.wheel_reporting = state;
         when 7787:       /* 'W': Application mousewheel mode */
           term.app_wheel = state;
+        when 7765:       /* 'A': Alt-Modified mousewheel mode */
+          term.alt_wheel = state;
         when 7796:       /* Bidi disable in current line */
           if (state)
             term.lines[term.curs.y]->lattr |= LATTR_NOBIDI;
@@ -2495,6 +2497,8 @@ get_mode(bool privatemode, int arg)
         return 2 - term.wheel_reporting;
       when 7787:       /* 'W': Application mousewheel mode */
         return 2 - term.app_wheel;
+      when 7765:       /* 'A': Alt-Modified mousewheel mode */
+        return 2 - term.alt_wheel;
       when 7796:       /* Bidi disable in current line */
         return 2 - !!(term.lines[term.curs.y]->lattr & LATTR_NOBIDI);
       when 77096:      /* Bidi disable */

--- a/wiki/CtrlSeqs.md
+++ b/wiki/CtrlSeqs.md
@@ -320,7 +320,23 @@ to private sequences (see below). To support these subtle differences,
 both can be switched independently.
 
 By default, mousewheel events are reported as cursor key presses, which enables
-mousewheel scrolling in applications such as **[less](http://www.greenwoodsoftware.com/less)** without requiring any configuration. Alternatively, mousewheel reporting can be switched to _application mousewheel mode_, where the mousewheel sends its own separate keycodes that allow an application to treat the mousewheel differently from cursor keys:
+mousewheel scrolling in applications such as
+**[less](http://www.greenwoodsoftware.com/less)** without requiring any
+configuration.
+
+The cursor keycodes sent for mousewheel events can optionally have the Alt
+modifier applied, to distinguish them from plain Up/Down key presses.
+For example, in the nano editor, Alt+Up/Down scrolls the window immediately,
+whereas plain Up/Down moves the cursor.
+
+_Alt-modified mousewheel mode_ is controlled by these sequences:
+
+| **sequence**  | **mode**      |
+|:--------------|:--------------|
+| `^[[?7765l`   | unmodified    |
+| `^[[?7765h`   | Alt-modified  |
+
+Alternatively, mousewheel reporting can be switched to _application mousewheel mode_, where the mousewheel sends its own separate keycodes that allow an application to treat the mousewheel differently from cursor keys:
 
 | **event**   | **code**    |
 |:------------|:------------|


### PR DESCRIPTION
Proposing the following three main changes to mousewheel handling. Further details in the individual commit messages.

### Avoid mixed line and page mousewheel scrolling

Don't convert line scrolling events to page scrolling events when they exceed the terminal height. This was my idea to start with, but in hindsight I don't think it was a good one because we don't actually know how many lines correspond to a page as far as the application is concerned, or whether it supports page up/down events in the first place. I think this simplifies the code a bit, and helps witht the following changes.

### Send Alt modifier with mousewheel events

If the Alt key is pressed, modify mousewheel events sent as cursor/page up/down keycodes or as mintty's application wheel codes accordingly.  (Ctrl and Shift are already used for other purposes.)

### Add Alt-modified mousewheel mode

When enabled, this sends Alt-modified cursor up/down keycodes for mousewheel events when the Alt key is not pressed. If the Alt key is pressed, unmodified keycodes are sent. The mode does not affect page up/down codes.

In the nano editor from version 4.0, the Alt+Up/Down keycodes scroll the window instead of moving the cursor. Scrolling straight away is the proper action for the mousewheel, whereas moving the cursor only scrolls once the cursor reaches the top or bottom. 

Less scrolls with or without the Alt modifier. Vim and mined at least tolerate Alt+Up/Down, apparently handling it the same as unmodified Up/Down, but they have proper mousewheel scrolling support using full mouse reporting mode anyway.