### PR TITLE
Support lone Alt key presses in KeyFunctions

### DIFF
--- a/docs/mintty.1
+++ b/docs/mintty.1
@@ -2966,9 +2966,9 @@ attached with a "+" separator, e.g. \fBCS+F9\fP;
 or a prefix "*" that applies the definition for all modified variations 
 of the key, e.g. \fB*Menu\fP
 .br
-\(en special keys (some of which do not occur on typical keyboards) 
-and keypad keys, as well as modified special and keypad keys; 
-Space, Enter, Esc and Tab are only considered with at least one modifier
+\(en special keys (some of which do not occur on typical keyboards)
+and keypad keys, as well as modified special and keypad keys.
+Space, Enter and Tab are only considered with at least one modifier.
   Esc, Tab
   Enter, KP_Enter
   Space, Back
@@ -2976,6 +2976,7 @@ Space, Enter, Esc and Tab are only considered with at least one modifier
   ScrollLock, NumLock, CapsLock
   (PrintScreen)
   LWin, RWin
+  Alt (when used on its own)
   Menu
   Insert, KP_Insert
   Delete, KP_Delete
@@ -3251,6 +3252,10 @@ Ctrl+_ assignment already
 \(en \fBKeyFunctions=C+F2:new-tab-cwd;AC+F2:new-window-cwd\fP will open 
 a new tab in same directory as current process on Control+F2, or as a 
 new window on Alt+Control+F2
+.br
+\(en \fBKeyFunctions=Alt:\(ha[\fP will make Alt send the Esc keycode when it is
+pressed and released on its own, for when the Esc key seems too far away from
+the home row.
 .br
 \(en \fBKeyFunctions=c:copy;v:paste\fP in combination with setting 
 \fB-o CtrlExchangeShift=true\fP will assign copy/paste to ^C and ^V 

--- a/src/wininput.c
+++ b/src/wininput.c
@@ -1,5 +1,5 @@
 // wininput.c (part of mintty)
-// Copyright 2008-22 Andy Koppe, 2015-2022 Thomas Wolff
+// Copyright 2008-23 Andy Koppe, 2015-2023 Thomas Wolff
 // Licensed under the terms of the GNU General Public License v3 or later.
 
 #include "winpriv.h"
@@ -2017,7 +2017,7 @@ static struct {
   {VK_TAB, 0, "Tab"},
   {VK_RETURN, 0, "Enter"},
   {VK_PAUSE, 1, "Pause"},
-  {VK_ESCAPE, 0, "Esc"},
+  {VK_ESCAPE, 1, "Esc"},
   {VK_SPACE, 0, "Space"},
   {VK_SNAPSHOT, 1, "PrintScreen"},
   {VK_LWIN, 1, "LWin"},
@@ -2563,7 +2563,8 @@ static LONG last_key_time = 0;
   }
 
   if (key == VK_MENU) {
-    if (!repeat && mods == MDK_ALT && alt_state == ALT_NONE)
+    if (!repeat && mods == MDK_ALT && alt_state == ALT_NONE &&
+        (!altgr0 || cfg.altgr_is_alt))
       alt_state = ALT_ALONE;
     return true;
   }
@@ -3911,6 +3912,8 @@ win_key_up(WPARAM wp, LPARAM lp)
   if (key == VK_MENU) {
     if (alt_state > ALT_ALONE && alt_code) {
       insert_alt_code();
+    } else if (alt_state == ALT_ALONE) {
+      pick_key_function(cfg.key_commands, "Alt", 0, key, 0, 0, scancode);
     }
     alt_state = ALT_NONE;
     return true;


### PR DESCRIPTION
A lone Alt key press in Windows applications normally brings up the application menu bar (which is why its virtual keycode is VK_MENU). There's no such menu bar in mintty, which relies on the context menu and window menu instead, so make lone Alt key presses available for mapping in the KeyFunctions setting.

The action is triggered when the Alt key is released, but only if no other modifier was down when the Alt key was pressed, and if nothing else was pressed in-between.

Also make sure that AltGr does not trigger this action or Alt code processing, unless the AltGrIsAlsoAlt setting is enabled.

One use case for this is to map Alt to the context menu via the 'menu-text' action, to make it easier to reach on keyboards that don't have the context menu key.

Another is to map it to ^[, i.e. the Esc key code, which might be convenient for vim users. It also makes plenty of sense as Alt modifier combinations normally prefix the modified key with ^[.

As the Esc key's default function can be replaced in this way, also make unmodified Esc key presses available for mapping in KeyFunctions. One use case for that is to map it to a non-letter control character such as ^\, and then use that as the interrupt character in the stty settings, instead of ^C. That gives Esc its usual Windows meaning of interrupting or cancelling actions, and makes ^C available for copying.