### PR TITLE
Fix option index overflow in remember_file_options

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1,5 +1,5 @@
 // config.c (part of mintty)
-// Copyright 2008-2022 Andy Koppe, 2015-2022 Thomas Wolff
+// Copyright 2008-2023 Andy Koppe, 2015-2023 Thomas Wolff
 // Based on code from PuTTY-0.60 by Simon Tatham and team.
 // Licensed under the terms of the GNU General Public License v3 or later.
 
@@ -845,7 +845,7 @@ find_option(bool from_file, string name)
 #define MAX_COMMENTS (lengthof(options) * 3)
 static struct {
   char * comment;
-  uchar opti;
+  ushort opti;
 } file_opts[lengthof(options) + MAX_COMMENTS];
 static uchar arg_opts[lengthof(options)];
 static uint file_opts_num = 0;


### PR DESCRIPTION
There are more than 256 config options (!), which means that using a uchar is no longer sufficient for storing the index of options found in the config file or changed in the UI.

The overflow meant that for example a BoldBlue setting in the config file (which currently has option index 262) turned into a TekForegroundColour setting (with index 6) when changing some unrelated setting in the config dialog and saving.