### PR TITLE
Update zh_CN.po

### DIFF
--- a/lang/zh_CN.po
+++ b/lang/zh_CN.po
@@ -637,7 +637,7 @@ msgstr "选中后立即复制(&Y)"
 #. __ Context menu:
 #: config.c:4133 config.c:4166 config.c:4332 wininput.c:684
 msgid "Copy with TABs"
-msgstr "以纯文本复制（包括 &Tab）"
+msgstr "复制时包含制表符"
 
 #. __ Options - Mouse:
 #. __ Options - Selection:


### PR DESCRIPTION
There's something wrong when displaying the previous translation: the latter part of the text was cut, which causes misunderstandings. Here is a better localization, concise and more understandable.
![465a0624e1849de780e3dd8f10b8e5ab](https://github.com/mintty/mintty/assets/139840508/330052cc-576d-47ad-885c-40f93deb4cf3)

