### PR TITLE
Some CJK characters don't follow the FontChoice option

### DIFF
--- a/src/termout.c
+++ b/src/termout.c
@@ -4987,6 +4987,10 @@ term_do_write(const char *buf, uint len, bool fix_status)
 
         cattrflags asav = term.curs.attr.attr;
 
+        uchar cf = scriptfont(wc);
+        if (cf && cf <= 10 && !(asav & FONTFAM_MASK))
+            term.curs.attr.attr = asav | ((cattrflags)cf << ATTR_FONTFAM_SHIFT);
+
         switch (cset) {
           when CSET_VT52DRW:  // VT52 "graphics" mode
             if (0x5E <= wc && wc <= 0x7E) {


### PR DESCRIPTION
The characters listed here (e.g. "「" (U+300C)) don't follow the FontChoice option:
https://github.com/mintty/mintty/blob/78c7d205d586ed87c946b00dc62034ea54c96e7b/src/termout.c#L5224-L5225

Consider the following settings:
```
Font=Anonymous Pro  # ASCII font
FontChoice=CJK:1
Font1=IPAGothic     # Japanese font
```

U+300C is a double width CJK character so `win_char_width()` should return 2 here:
https://github.com/mintty/mintty/blob/78c7d205d586ed87c946b00dc62034ea54c96e7b/src/termout.c#L5222-L5231

However, FONTFAM is not set to `term.curs.attr.attr` at this point, then `win_char_width()` returns 1 and the `TATTR_EXPAND` flag is unintentionally set.  As the result, U+300C is not shown correctly. (The left half of the glyph of U+300C is expanded.)

FONTFAM should be set before calling `win_char_width()`.