### PR TITLE
Update monokai-dimmed

### DIFF
--- a/themes/monokai-dimmed
+++ b/themes/monokai-dimmed
@@ -2,7 +2,7 @@
 
 BackgroundColour=31,31,31
 ForegroundColour=185,188,186
-CursorColour=185,188,186
+CursorColour=248,62,25
 Black=58,61,67
 BoldBlack=136,137,135
 Red=190,63,72


### PR DESCRIPTION
correct cursor color to match theme upstream. For some reason my original pull didn't match upstream value.