### PR TITLE
add: tender theme

### DIFF
--- a/themes/tender
+++ b/themes/tender
@@ -1,0 +1,23 @@
+# Based off of the theme for vim: https://github.com/jacoborus/tender.vim
+# Mintty theme converted by: https://github.com/compEng0001/tender-mintty
+# Licence: MIT
+
+BackgroundColour=28,28,28
+ForegroundColour=197,200,198
+CursorColour=197,200,198
+Black=40,40,40
+BoldBlack=60,56,54
+Red=251,73,52
+BoldRed=204,36,29
+Green=184,187,38
+BoldGreen=152,151,26
+Yellow=250,189,47
+BoldYellow=215,153,33
+Blue=131,165,152
+BoldBlue=69,133,136
+Magenta=211,134,155
+BoldMagenta=177,98,134
+Cyan=142,192,155
+BoldCyan=104,157,106
+White=235,219,178
+BoldWhite=251,241,199


### PR DESCRIPTION
I have added the tender theme, which is based off of [tender.vim](https://github.com/jacoborus/tender.vim). 

- tender.vim, pull requests [#63](https://github.com/jacoborus/tender.vim/pull/63) & [#64](https://github.com/jacoborus/tender.vim/pull/64)

- Kitty-themes, pull request [#125](https://github.com/kovidgoyal/kitty-themes/pull/125)
## Screenshots

![image](https://github.com/user-attachments/assets/43cb3353-f560-42ef-b0e9-5b0c6d874a67)

>Note: I am using Starship, Dejavu Sans Mono 10pt
