### PR TITLE
Initialise the timestamp earlier

### DIFF
--- a/src/winmain.c
+++ b/src/winmain.c
@@ -7798,6 +7798,9 @@ static int dynfonts = 0;
   win_synctabs(4);
 #endif
 
+  // mark userdata with timestamp, for initial tabbar ordering
+  SetWindowLong(wnd, GWL_USERDATA, mtime() & GWL_TIMEMASK);
+
   update_tab_titles();
 
 #ifdef always_hook_keyboard
@@ -7968,9 +7971,6 @@ static int dynfonts = 0;
   // and grab focus again, just in case and for Windows 11
   // (https://github.com/mintty/mintty/issues/1113#issuecomment-1210278957)
   SetFocus(wnd);
-
-  // mark userdata with timestamp, for initial tabbar ordering
-  SetWindowLong(wnd, GWL_USERDATA, mtime() & GWL_TIMEMASK);
 
   is_init = true;
   // tab management: secure transparency appearance by hiding other tabs


### PR DESCRIPTION
When opening a new tab, it is shown at the left-most tab, and after a while, it is moved to the right-most part since
fa1f16bc772b049872ef2a1ada85dbfd0f1dc898.

Initialise the timestamp earlier so a new tab is shown at the right-most part.