### PR TITLE
Restore focus after tab reordering

### DIFF
--- a/src/wintab.c
+++ b/src/wintab.c
@@ -232,6 +232,7 @@ static HCURSOR hcursor = NULL;
     SetCursor(hcursor);
     ReleaseCapture();
     dragidx = -1;
+    SetFocus(wnd);
   }
   else if (msg == WM_NOTIFY) {
     //printf("tabbar con_proc WM_NOTIFY\n");


### PR DESCRIPTION
Set the focus to the main window after tab reordering is finished.

Users couldn't type texts or commands after tab reordering without clicking the main window.