### PR TITLE
Add support to sync Windows Theme with mintty

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1881,8 +1881,8 @@ apply_config(bool save)
       if (changed)
         remember_file_option("apply", i);
     }
-
   }
+
   copy_config("apply", &file_cfg, &new_cfg);
   if (wcscmp(new_cfg.lang, cfg.lang) != 0
       || (wcscmp(new_cfg.lang, W("=")) == 0 && new_cfg.locale != cfg.locale)

--- a/src/config.c
+++ b/src/config.c
@@ -64,6 +64,7 @@ const config default_cfg = {
   .theme_file = W(""),
   .background = W(""),
   .colour_scheme = "",
+  .use_windows_theme = false,
   .transparency = 0,
   .blurred = false,
   .opaque_when_focused = false,
@@ -366,6 +367,7 @@ options[] = {
   {"ThemeFile", OPT_WSTRING, offcfg(theme_file)},
   {"Background", OPT_WSTRING, offcfg(background)},
   {"ColourScheme", OPT_STRING, offcfg(colour_scheme)},
+  {"UseWindowsTheme", OPT_BOOL, offcfg(use_windows_theme)},
   {"Transparency", OPT_TRANS, offcfg(transparency)},
 #ifdef support_blurred
   {"Blur", OPT_BOOL, offcfg(blurred)},
@@ -1880,7 +1882,6 @@ apply_config(bool save)
         remember_file_option("apply", i);
     }
   }
-
   copy_config("apply", &file_cfg, &new_cfg);
   if (wcscmp(new_cfg.lang, cfg.lang) != 0
       || (wcscmp(new_cfg.lang, W("=")) == 0 && new_cfg.locale != cfg.locale)
@@ -1903,6 +1904,16 @@ apply_config(bool save)
     win_invalidate_all(false);
   }
   else if (had_theme) {
+    win_reset_colours();
+    win_invalidate_all(false);
+  } else if(cfg.use_windows_theme) {
+    uint val = getregval(HKEY_CURRENT_USER, W("Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize"), W("AppsUseLightTheme"));
+    //Means Windows is using dark mode, or is not defined (With also means is using dark mode)
+    if (val == 0) {
+      load_theme(W("windows10"));
+    } else {
+      load_theme(W("kohlrausch"));
+    }
     win_reset_colours();
     win_invalidate_all(false);
   }
@@ -3756,6 +3767,10 @@ setup_config_box(controlbox * b)
   (store_button = ctrl_pushbutton(s, _("Store"), scheme_saver, 0))
     ->column = 1;
 
+  ctrl_checkbox(
+    //__ Options - Looks: cursor feature
+    s, _("Use Windows Theme"), dlg_stdcheckbox_handler, &new_cfg.use_windows_theme
+  );
   s = ctrl_new_set(b, _("Looks"), null, 
   //__ Options - Looks: section title
                       _("Transparency"));

--- a/src/config.c
+++ b/src/config.c
@@ -62,9 +62,9 @@ const config default_cfg = {
   .search_bg_colour = 0x00DDDD,
   .search_current_colour = 0x0099DD,
   .theme_file = W(""),
+  .dark_theme = W(""),
   .background = W(""),
   .colour_scheme = "",
-  .dark_theme = W(""),
   .transparency = 0,
   .blurred = false,
   .opaque_when_focused = false,
@@ -365,9 +365,9 @@ options[] = {
   {"SearchBackgroundColour", OPT_COLOUR, offcfg(search_bg_colour)},
   {"SearchCurrentColour", OPT_COLOUR, offcfg(search_current_colour)},
   {"ThemeFile", OPT_WSTRING, offcfg(theme_file)},
+  {"DarkTheme", OPT_WSTRING, offcfg(dark_theme)},
   {"Background", OPT_WSTRING, offcfg(background)},
   {"ColourScheme", OPT_STRING, offcfg(colour_scheme)},
-  {"DarkTheme", OPT_WSTRING, offcfg(dark_theme)},
   {"Transparency", OPT_TRANS, offcfg(transparency)},
 #ifdef support_blurred
   {"Blur", OPT_BOOL, offcfg(blurred)},
@@ -1881,6 +1881,7 @@ apply_config(bool save)
       if (changed)
         remember_file_option("apply", i);
     }
+
   }
   copy_config("apply", &file_cfg, &new_cfg);
   if (wcscmp(new_cfg.lang, cfg.lang) != 0
@@ -1902,7 +1903,7 @@ apply_config(bool save)
     load_theme(cfg.theme_file);
     win_reset_colours();
     win_invalidate_all(false);
-  } else if(*cfg.dark_theme) {
+  } else if (*cfg.dark_theme) {
     uint val = getregval(HKEY_CURRENT_USER, W("Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize"), W("AppsUseLightTheme"));
     //Means Windows is using dark mode, or is not defined (With also means is using dark mode)
     if (val == 0) {
@@ -1910,6 +1911,7 @@ apply_config(bool save)
     } else {
       load_theme(cfg.theme_file);
     }
+
     win_reset_colours();
     win_invalidate_all(false);
   }
@@ -2931,7 +2933,7 @@ scheme_return:
 }
 
 static void
-set_new_cfg(control *ctrl, config *new_cfg, wstring theme_name)
+set_new_cfg_theme(control *ctrl, config *new_cfg, wstring theme_name)
 {
   if (strcmp(ctrl->label, "&Theme") == 0) {
     new_cfg->theme_file = theme_name;
@@ -2977,14 +2979,14 @@ theme_handler(control *ctrl, int event)
     else
       dlg_editbox_get_w(ctrl, &theme_name);
 
-    set_new_cfg(ctrl, &new_cfg, theme_name);
+    set_new_cfg_theme(ctrl, &new_cfg, theme_name);
     // clear pending colour scheme
     strset(&new_cfg.colour_scheme, "");
     enable_widget(store_button, false);
   }
   else if (event == EVENT_VALCHANGE) {  // pasted or typed-in
     dlg_editbox_get_w(ctrl, &theme_name);
-    set_new_cfg(ctrl, &new_cfg, theme_name);
+    set_new_cfg_theme(ctrl, &new_cfg, theme_name);
     enable_widget(store_button,
                   *new_cfg.colour_scheme && *theme_name
                   && !wcschr(theme_name, L'/') && !wcschr(theme_name, L'\\')

--- a/src/config.h
+++ b/src/config.h
@@ -252,7 +252,7 @@ typedef struct {
   string word_chars_excl;
   colour ime_cursor_colour;
   colour_pair ansi_colours[16];
-  bool use_windows_theme;
+  wstring dark_theme;
   wstring sixel_clip_char;
   bool short_long_opts;
   bool bold_as_special;

--- a/src/config.h
+++ b/src/config.h
@@ -252,6 +252,7 @@ typedef struct {
   string word_chars_excl;
   colour ime_cursor_colour;
   colour_pair ansi_colours[16];
+  bool use_windows_theme;
   wstring sixel_clip_char;
   bool short_long_opts;
   bool bold_as_special;

--- a/src/config.h
+++ b/src/config.h
@@ -66,6 +66,7 @@ typedef struct {
   colour sel_fg_colour, sel_bg_colour;
   colour search_fg_colour, search_bg_colour, search_current_colour;
   wstring theme_file;
+  wstring dark_theme;
   wstring background;
   string colour_scheme;
   char transparency;
@@ -252,7 +253,6 @@ typedef struct {
   string word_chars_excl;
   colour ime_cursor_colour;
   colour_pair ansi_colours[16];
-  wstring dark_theme;
   wstring sixel_clip_char;
   bool short_long_opts;
   bool bold_as_special;

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -6820,7 +6820,7 @@ main(int argc, char *argv[])
     load_scheme(cfg.colour_scheme);
   else if (*cfg.theme_file)
     load_theme(cfg.theme_file);
-  else if (cfg.use_windows_theme) {
+  else if (*cfg.dark_theme) {
       uint val = getregval(HKEY_CURRENT_USER, W("Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize"), W("AppsUseLightTheme"));
       if (val == 0) {
         load_theme(W("windows10"));
@@ -8022,15 +8022,15 @@ static int dynfonts = 0;
 #else
       check_unhide_or_clear_tab();
 #endif
-      if(cfg.use_windows_theme) {
+      if(*cfg.dark_theme) {
         uint val = getregval(HKEY_CURRENT_USER, W("Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize"), W("AppsUseLightTheme"));
         if (initial_value != val) {
           initial_value = val;
 
           if (val == 0) {
-            load_theme(W("windows10"));
+            load_theme(cfg.dark_theme);
           } else {
-            load_theme(W("kohlrausch"));
+            load_theme(cfg.theme_file);
           }
           win_reset_colours();
           win_invalidate_all(false);

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -8022,7 +8022,7 @@ static int dynfonts = 0;
 #else
       check_unhide_or_clear_tab();
 #endif
-      if(*cfg.dark_theme) {
+      if (*cfg.dark_theme) {
         uint val = getregval(HKEY_CURRENT_USER, W("Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize"), W("AppsUseLightTheme"));
         if (theme_reg_value != val) {
           theme_reg_value = val;

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -8010,7 +8010,7 @@ static int dynfonts = 0;
   is_init = true;
   // tab management: secure transparency appearance by hiding other tabs
   win_set_tab_focus('I');  // hide other tabs
-  uint initial_value = 2;
+  uint theme_reg_value = 2;  // We use this variable to avoid keep loading the theme all the time, so we start with an impossible value, and then we check if it changed from 0 to 1.
   // Message loop.
   for (;;) {
     MSG msg;
@@ -8024,8 +8024,8 @@ static int dynfonts = 0;
 #endif
       if(*cfg.dark_theme) {
         uint val = getregval(HKEY_CURRENT_USER, W("Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize"), W("AppsUseLightTheme"));
-        if (initial_value != val) {
-          initial_value = val;
+        if (theme_reg_value != val) {
+          theme_reg_value = val;
 
           if (val == 0) {
             load_theme(cfg.dark_theme);

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -6820,6 +6820,14 @@ main(int argc, char *argv[])
     load_scheme(cfg.colour_scheme);
   else if (*cfg.theme_file)
     load_theme(cfg.theme_file);
+  else if (cfg.use_windows_theme) {
+      uint val = getregval(HKEY_CURRENT_USER, W("Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize"), W("AppsUseLightTheme"));
+      if (val == 0) {
+        load_theme(W("windows10"));
+      } else {
+        load_theme(W("kohlrausch"));
+      }
+  }
 
   if (!wdpresent) {  // shortcut start directory is empty
     WCHAR cd[MAX_PATH + 1];
@@ -8002,7 +8010,7 @@ static int dynfonts = 0;
   is_init = true;
   // tab management: secure transparency appearance by hiding other tabs
   win_set_tab_focus('I');  // hide other tabs
-
+  uint initial_value = 2;
   // Message loop.
   for (;;) {
     MSG msg;
@@ -8014,7 +8022,20 @@ static int dynfonts = 0;
 #else
       check_unhide_or_clear_tab();
 #endif
+      if(cfg.use_windows_theme) {
+        uint val = getregval(HKEY_CURRENT_USER, W("Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize"), W("AppsUseLightTheme"));
+        if (initial_value != val) {
+          initial_value = val;
 
+          if (val == 0) {
+            load_theme(W("windows10"));
+          } else {
+            load_theme(W("kohlrausch"));
+          }
+          win_reset_colours();
+          win_invalidate_all(false);
+        }
+      }
       if (msg.message == WM_QUIT)
         return msg.wParam;
       if (!IsDialogMessage(config_wnd, &msg)) {


### PR DESCRIPTION
As discussed in issue #1303, this PR allows Mintty to sync when the user changes the "app mode" in Windows 10/11.

1. A single new option was added, "Dark theme"
2. The size of the dropdown "Theme" was changed to match the size of the new dropdown
3. Add a new option in the config called "dark_theme", with the default value as empty.

![image](https://github.com/user-attachments/assets/d9ac1662-97fe-46e1-9d19-375552b09e22)

A few points on my side:

1. There might be a better place to add the check for the value change, I added it to the src/winmain.c for convenience.
2. theme_handler wasn't ready to accept more than one dropdown config, I did my best to change the least amount of code as possible, but my test might not have covered all the scenarios
3. One config being called "theme_file" and the other "dark_theme" might not be the best, suggestions?


