### PR TITLE
Fix integer overflow in CSI/DCS/OSC parameter parsing

### DIFF
--- a/src/termout.c
+++ b/src/termout.c
@@ -5813,8 +5813,9 @@ term_do_write(const char *buf, uint len, bool fix_status)
         else if (c >= '0' && c <= '9') {
           uint i = term.csi_argc - 1;
           if (i < lengthof(term.csi_argv)) {
-            term.csi_argv[i] = 10 * term.csi_argv[i] + c - '0';
-            if ((int)term.csi_argv[i] < 0)
+            if (term.csi_argv[i] <= (UINT_MAX - (uint)(c - '0')) / 10)
+              term.csi_argv[i] = 10 * term.csi_argv[i] + (uint)(c - '0');
+            else
               term.csi_argv[i] = INT_MAX;  // capture overflow
             term.csi_argv_defined[i] = 1;
           }
@@ -5873,9 +5874,10 @@ term_do_write(const char *buf, uint len, bool fix_status)
       when OSC_NUM:
         switch (c) {
           when '0' ... '9':  /* OSC command number */
-            term.cmd_num = term.cmd_num * 10 + c - '0';
-            if (term.cmd_num < 0)
-              term.cmd_num = -99;  // prevent wrong valid param
+            if (term.cmd_num <= (INT_MAX - (c - '0')) / 10)
+              term.cmd_num = term.cmd_num * 10 + (c - '0');
+            else
+              term.cmd_num = INT_MAX;  // prevent wrong valid param
           when ';':
             term.state = CMD_STRING;
           when '\a':
@@ -5991,7 +5993,10 @@ term_do_write(const char *buf, uint len, bool fix_status)
             //printf("DCS param %c\n", c);
             if (term.csi_argc < 2) {
               uint i = term.csi_argc;
-              term.csi_argv[i] = 10 * term.csi_argv[i] + c - '0';
+              if (term.csi_argv[i] <= (UINT_MAX - (uint)(c - '0')) / 10)
+                term.csi_argv[i] = 10 * term.csi_argv[i] + (uint)(c - '0');
+              else
+                term.csi_argv[i] = UINT_MAX;  // cap on overflow
             }
           when ';' or ':':  /* DCS parameter separator */
             //printf("DCS param sep %c\n", c);


### PR DESCRIPTION
## Summary

Three integer overflow defects in `term_do_write()` in `src/termout.c`:

1. **CSI parameter accumulation** (~line 5813): `csi_argv[i]` is `uint`. The post-multiply check `(int)csi_argv[i] < 0` only catches overflow into the sign bit. A full wraparound — e.g. `429496730 * 10` wraps to `4` — produces a small positive value that bypasses the check entirely, silently applying a wrong terminal attribute/command.

2. **OSC command number** (~line 5874): `cmd_num * 10` is **signed integer overflow, which is undefined behavior in C**. A compiler is permitted to optimize away the `if (cmd_num < 0)` guard entirely on the basis that signed overflow cannot happen. Reproduced with GCC/Clang at `-O2`.

3. **DCS parameter** (~line 5993): Same uint overflow as CSI, but with **no overflow check at all**. The single consumer (Synchronized Update, `DCS =1s` / `DCS =2s`) compares against exact values 1 and 2, so a wrapped value is currently harmless — but any future DCS handler inherits the unprotected accumulation.

## Fix

Replace all three post-multiply checks with pre-multiply bounds checks:

```c
// Before (CSI)
term.csi_argv[i] = 10 * term.csi_argv[i] + c - '0';
if ((int)term.csi_argv[i] < 0)
    term.csi_argv[i] = INT_MAX;  // capture overflow

// After
if (term.csi_argv[i] <= (UINT_MAX - (uint)(c - '0')) / 10)
    term.csi_argv[i] = 10 * term.csi_argv[i] + (uint)(c - '0');
else
    term.csi_argv[i] = INT_MAX;  // capture overflow
```

The CSI cap is kept at `INT_MAX` (not `UINT_MAX`) to avoid setting bit 31, which would collide with the `SUB_PARS` flag and cause the SGR sub-parameter path to misfire. The DCS cap uses `UINT_MAX` since DCS never uses SUB_PARS tagging.

## Exploitability

**These are not exploitable for memory safety.** All current consumers of `csi_argv` either compare against specific switch/case values, clamp to screen dimensions, or truncate to `short` with bounds checks. The OSC dispatcher ignores unrecognized `cmd_num` values. No path from a wrapped parameter value to an out-of-bounds memory access was found.

The OSC UB issue is the most important: the existing overflow guard is something a compiler can legally delete, leaving no protection at all. The CSI double-wrap case is a real correctness bug (wrong terminal rendering for crafted sequences). The DCS case is defense-in-depth.

## Analysis note

This was identified and fixed with assistance from Anthropic Claude (AI-assisted analysis and code generation). The fixes were independently verified by a second Claude analysis pass to confirm correctness of the pre-multiply arithmetic and the INT_MAX/UINT_MAX cap choices. I'm happy to close this if you'd prefer to handle overflow checks differently — please treat it as a starting point for discussion rather than a mandatory change.

## Testing

- Verified the three patched accumulation sites are the only `* 10` digit-accumulation loops in `term_do_write()`
- Bounds-check arithmetic proven: `v <= (UINT_MAX - d) / 10` iff `10v + d <= UINT_MAX` (unsigned); `v <= (INT_MAX - d) / 10` iff `10v + d <= INT_MAX` (signed, non-negative `v`)
- Cherry-pick applies cleanly to current master with no conflicts