### PR TITLE
`isnanf()` fix for 32-bit

### DIFF
--- a/src/regis.c
+++ b/src/regis.c
@@ -797,7 +797,12 @@ rgbToHsl(float r, float g, float b)
   if (maxcolor == 2)
     h = 4 + (r - g) / (max - min);
 
+// ifnanf() is not available on 32-bit platforms.
+#ifdef i386
+  if (isnan(h))
+#else
   if (isnanf(h))
+#endif
     h = 0;
   h *= 60;
   if (h < 0)

--- a/src/regis.c
+++ b/src/regis.c
@@ -797,7 +797,7 @@ rgbToHsl(float r, float g, float b)
   if (maxcolor == 2)
     h = 4 + (r - g) / (max - min);
 
-// ifnanf() is not available on 32-bit platforms.
+// isnanf() is not available on 32-bit platforms.
 #ifdef i386
   if (isnan(h))
 #else


### PR DESCRIPTION
`isnanf()` is not available on 32-bit platforms. I found this out because I tried to compile it on my laptop, and it wouldn't compile.

This is a simple fix. I'm not really sure what the preprocessor directive is for 32-bit, but `i386` worked for me.

While reading what `h` was, it seems to be that it's not defined as a float (there is a line defining it as such, but it is commented out, along with many other single character variables), so I'm pretty sure it can use `isnan()` normally, but I don't know a lot of C, so take that with a grain of salt. It's up to you to do that.