### PR TITLE
docs: fix typo availabilty -> availability

### DIFF
--- a/wiki/CtrlSeqs.md
+++ b/wiki/CtrlSeqs.md
@@ -615,7 +615,7 @@ The following rules describe the character sequences to be handled as
 5. The zero-width joiner U+200D forces the subsequent character to 
    also be treated like a combining character, thus not add any width.
 
-Note that by rule 0 neither actual glyph availabilty nor the listing 
+Note that by rule 0 neither actual glyph availability nor the listing 
 of an emoji sequence in Unicode data is required; this is important to 
 keep screen width predictable for applications; otherwise screen 
 positioning would be hardly manageable with respect to changing 


### PR DESCRIPTION
Corrects the misspelling `availabilty` -> `availability` in `wiki/CtrlSeqs.md`.